### PR TITLE
feat: initial struct implementation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,3 +11,5 @@
 - If the user needs help with an Nx configuration or project graph error, use the `nx_workspace` tool to get any errors
 
 <!-- nx configuration end-->
+
+- E2E tests (against example-robot) are run with `nx run example-client:e2e:local` (starts the robot, then runs the e2e suite)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,3 +13,5 @@
 <!-- nx configuration end-->
 
 - E2E tests (against example-robot) are run with `nx run example-client:e2e:local` (starts the robot, then runs the e2e suite)
+- Unit tests: run `nx test <project>` (e.g. `nx test client`, `nx test react`). To run a single test file, use `nx test <project> --testFile=<name>` where `<name>` is a substring of the filename (e.g. `nx test client --testFile=struct-parser`). Do **not** invoke `vitest` directly — the Nx executor provides the required globals (describe, it, expect) and project-level config.
+- To run multiple project tests in one command: `nx run-many -t test --projects=client,react`

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A TypeScript library for communication over [WPILib's NetworkTables 4.1 protocol
 - Callbacks for connection listeners
 - Wildcard prefix listeners for multiple topics
 - Protobuf support with optional type generation and Zod validation
+- Struct support for WPILib types (Pose2d, Translation2d, etc.) with `createStructTopic` and `useStructTopic`
 - Retrying for messages queued during a connection loss
 - On-the-fly server switching with resubscribing and republishing
 - Generic types for Topics
@@ -231,6 +232,53 @@ const sensorTopic = ntcore.createProtobufTopic<{ timestamp: number; value: numbe
 await sensorTopic.publish();
 sensorTopic.setValue({ timestamp: Date.now(), value: 42.5 });
 ```
+
+### Struct Topics
+
+For WPILib struct types (e.g., `Pose2d`, `Translation2d`) over NetworkTables, use `createStructTopic` instead of `createTopic`. Structs use fixed-size binary serialization and interoperate with WPILib Java and C++ clients.
+
+**Built-in struct types:** Translation2d, Rotation2d, Pose2d, Transform2d, Twist2d, Translation3d, Quaternion, Rotation3d, Pose3d, Transform3d, Twist3d.
+
+**Subscribing to a struct topic** (e.g., a topic announced by the robot):
+
+```typescript
+import { NetworkTables } from '@ntcore/client';
+import { z } from 'zod';
+
+const ntcore = NetworkTables.getInstanceByTeam(973);
+
+const pose2dSchema = z.object({
+  translation: z.object({ x: z.number(), y: z.number() }),
+  rotation: z.object({ value: z.number() }),
+});
+type Pose2d = z.infer<typeof pose2dSchema>;
+
+const poseTopic = ntcore.createStructTopic<Pose2d>('/MyTable/PoseStruct', {
+  typeName: 'Pose2d',
+  validator: pose2dSchema,
+});
+poseTopic.subscribe((value) => {
+  console.log(`Pose: x=${value?.translation.x}, y=${value?.translation.y}`);
+});
+```
+
+**Publishing to a struct topic** (with custom schema for types not built-in):
+
+```typescript
+const customTopic = ntcore.createStructTopic<{ x: number; y: number }>('/MyTable/Custom2d', {
+  typeName: 'Custom2d',
+  schema: 'double x;double y',
+});
+
+await customTopic.publish();
+customTopic.setValue({ x: 1.5, y: -2.0 });
+```
+
+**Array of structs:** Use `typeName: 'Translation2d[]'` (or `Pose2d[]`, etc.) for topics that publish arrays of structs.
+
+**React:** Use `useStructTopic` from `@ntcore/react` for subscribing and optionally publishing struct topics in React components.
+
+> **Note:** Struct fields using `int64` or `uint64` are returned as JavaScript `number`, which has a precision limit of ±2^53. Values beyond `Number.MAX_SAFE_INTEGER` will lose precision. No built-in WPILib struct types are affected (they all use `double`).
 
 ### Subscribing to All Topics
 

--- a/apps/example-client/src/e2e/nt-server.spec.ts
+++ b/apps/example-client/src/e2e/nt-server.spec.ts
@@ -166,6 +166,42 @@ describe('E2E: NT server (example-robot)', () => {
       },
       VALUE_WAIT_MS + 5000
     );
+
+    it(
+      'createStructTopic reuse applies options (schema + defaultValue) when same name called again',
+      async () => {
+        const name = '/MyTable/StructReuseE2E';
+        const topic1 = nt.createStructTopic<{ x: number; y: number }>(name, { typeName: 'Translation2d' });
+        const topic2 = nt.createStructTopic<{ x: number; y: number }>(name, {
+          typeName: 'Translation2d',
+          schema: 'double x;double y',
+          defaultValue: { x: 10, y: 20 },
+        });
+        expect(topic2).toBe(topic1);
+        expect(topic2.getValue()).toEqual({ x: 10, y: 20 });
+      },
+      VALUE_WAIT_MS + 2000
+    );
+
+    it(
+      'createStructTopic with array type (Translation2d[]): publish, setValue, getValue round-trip',
+      async () => {
+        type Translation2d = { x: number; y: number };
+        const topic = nt.createStructTopic<Translation2d[]>('/MyTable/Translation2dArray', {
+          typeName: 'Translation2d[]',
+        });
+        expect(topic.typeInfo[1]).toBe('struct:Translation2d[]');
+        await topic.publish({ retained: true });
+
+        const arr: Translation2d[] = [
+          { x: 1.5, y: 2.5 },
+          { x: 3.5, y: 4.5 },
+        ];
+        topic.setValue(arr);
+        expect(topic.getValue()).toEqual(arr);
+      },
+      VALUE_WAIT_MS + 5000
+    );
   });
 
   describe('prefix topic (Accelerometer) + our AutoMode change', () => {

--- a/apps/example-client/src/e2e/nt-server.spec.ts
+++ b/apps/example-client/src/e2e/nt-server.spec.ts
@@ -98,6 +98,74 @@ describe('E2E: NT server (example-robot)', () => {
       },
       VALUE_WAIT_MS + 5000
     );
+
+    it(
+      'receives Pose (struct) from server via createStructTopic',
+      async () => {
+        const poseStructTopic = nt.createStructTopic<zod.infer<typeof pose2dSchema>>('/MyTable/PoseStruct', {
+          typeName: 'Pose2d',
+          validator: pose2dSchema,
+        });
+        const value = await new Promise<zod.infer<typeof pose2dSchema>>((resolve, reject) => {
+          const t = setTimeout(() => reject(new Error('PoseStruct value timeout')), VALUE_WAIT_MS);
+          poseStructTopic.subscribe((v) => {
+            if (v?.translation != null && v?.rotation != null) {
+              clearTimeout(t);
+              resolve(v);
+            }
+          });
+        });
+        expect(value.translation.x).toBeGreaterThanOrEqual(-2);
+        expect(value.translation.x).toBeLessThanOrEqual(2);
+        expect(value.translation.y).toBeGreaterThanOrEqual(0);
+        expect(value.translation.y).toBeLessThanOrEqual(3);
+        expect(value.rotation.value).toBeGreaterThanOrEqual(-Math.PI);
+        expect(value.rotation.value).toBeLessThanOrEqual(Math.PI);
+      },
+      VALUE_WAIT_MS + 5000
+    );
+  });
+
+  describe('client → robot', () => {
+    it(
+      'client publishes Pose2d struct; robot consumes and echoes to PoseStructEcho',
+      async () => {
+        const publishTopic = nt.createStructTopic<zod.infer<typeof pose2dSchema>>('/MyTable/PoseStructFromClient', {
+          typeName: 'Pose2d',
+          validator: pose2dSchema,
+        });
+        await publishTopic.publish({ retained: true });
+
+        const testPose = {
+          translation: { x: 0.5, y: 1.25 },
+          rotation: { value: Math.PI / 4 },
+        };
+        publishTopic.setValue(testPose);
+
+        const echoTopic = nt.createStructTopic<zod.infer<typeof pose2dSchema>>('/MyTable/PoseStructEcho', {
+          typeName: 'Pose2d',
+          validator: pose2dSchema,
+        });
+        const echoed = await new Promise<zod.infer<typeof pose2dSchema>>((resolve, reject) => {
+          const t = setTimeout(() => reject(new Error('PoseStructEcho value timeout')), VALUE_WAIT_MS);
+          echoTopic.subscribe((v) => {
+            if (
+              v?.translation != null &&
+              v?.rotation != null &&
+              Math.abs(v.translation.x - testPose.translation.x) < 1e-6 &&
+              Math.abs(v.translation.y - testPose.translation.y) < 1e-6
+            ) {
+              clearTimeout(t);
+              resolve(v);
+            }
+          });
+        });
+        expect(echoed.translation.x).toBeCloseTo(testPose.translation.x);
+        expect(echoed.translation.y).toBeCloseTo(testPose.translation.y);
+        expect(echoed.rotation.value).toBeCloseTo(testPose.rotation.value);
+      },
+      VALUE_WAIT_MS + 5000
+    );
   });
 
   describe('prefix topic (Accelerometer) + our AutoMode change', () => {

--- a/apps/example-client/src/main.ts
+++ b/apps/example-client/src/main.ts
@@ -76,6 +76,20 @@ poseTopic.subscribe((value) => {
   );
 });
 
+// --------------------------------------------------------- //
+// Example of using a struct topic to subscribe to a value    //
+// --------------------------------------------------------- //
+
+const poseStructTopic = ntcore.createStructTopic<zod.infer<typeof pose2dSchema>>('/MyTable/PoseStruct', {
+  typeName: 'Pose2d',
+  validator: pose2dSchema,
+});
+poseStructTopic.subscribe((value) => {
+  console.log(
+    `[Pose Struct Topic] Got Pose Value: x: ${value?.translation.x}, y: ${value?.translation.y}, rotation: ${value?.rotation.value}`
+  );
+});
+
 // --------------------------------------------------------------- //
 // Example of using a prefix topic to subscribe to multiple topics //
 // --------------------------------------------------------------- //

--- a/apps/example-react/src/app/App.tsx
+++ b/apps/example-react/src/app/App.tsx
@@ -6,6 +6,7 @@ import { ConnectionStatus } from '../components/ConnectionStatus';
 import { GyroCard } from '../components/GyroCard';
 import { AccelerometerCard } from '../components/AccelerometerCard';
 import { PoseCard } from '../components/PoseCard';
+import { PoseStructCard } from '../components/PoseStructCard';
 import { AutoModeCard } from '../components/AutoModeCard';
 import { AllTopicsTable } from '../components/AllTopicsTable';
 
@@ -50,6 +51,7 @@ export default function App() {
           </div>
         </div>
         <PoseCard />
+        <PoseStructCard />
         <AutoModeCard />
         <AllTopicsTable />
       </div>

--- a/apps/example-react/src/components/PoseStructCard.tsx
+++ b/apps/example-react/src/components/PoseStructCard.tsx
@@ -1,0 +1,59 @@
+import { z } from 'zod';
+import { useStructTopic } from '@ntcore/react';
+import { mathDegreesToDisplayDegrees, normalizeDegrees, useShortestPathDisplay } from '../utils/angle';
+import { ValueCard } from './ValueCard';
+import './PoseCard.scss';
+
+const translation2dSchema = z.object({ x: z.number(), y: z.number() });
+const rotation2dSchema = z.object({ value: z.number() });
+const pose2dSchema = z.object({
+  translation: translation2dSchema,
+  rotation: rotation2dSchema,
+});
+type Pose2d = z.infer<typeof pose2dSchema>;
+
+const FIELD_HALF = 4;
+
+function radToDeg(rad: number): number {
+  return (rad * 180) / Math.PI;
+}
+
+export function PoseStructCard() {
+  const { value: pose } = useStructTopic<Pose2d>('/MyTable/PoseStruct', {
+    typeName: 'Pose2d',
+    validator: pose2dSchema,
+  });
+
+  const x = pose?.translation.x ?? 0;
+  const y = pose?.translation.y ?? 0;
+  const rotRad = pose?.rotation.value ?? 0;
+  const rotDeg = radToDeg(rotRad);
+  const displayAngleDeg = pose != null ? mathDegreesToDisplayDegrees(rotDeg) : null;
+  const normalized = displayAngleDeg != null ? normalizeDegrees(displayAngleDeg) : null;
+  const displayRotation = useShortestPathDisplay(normalized);
+
+  const percentX = 50 + (x / FIELD_HALF) * 50;
+  const percentY = 50 - (y / FIELD_HALF) * 50;
+
+  return (
+    <ValueCard title="Pose (Struct)" className="pose-card">
+      <div className="pose-field" aria-label="Robot pose on field (struct topic, top-down)">
+        <div className="pose-grid" aria-hidden />
+        <div
+          className="pose-robot"
+          style={{
+            left: `${Math.max(5, Math.min(95, percentX))}%`,
+            top: `${Math.max(5, Math.min(95, percentY))}%`,
+            transform: `translate(-50%, -50%) rotate(${displayRotation}deg)`,
+          }}
+          aria-hidden
+        />
+      </div>
+      <div className="pose-readout">
+        <span>x: {pose != null ? pose.translation.x.toFixed(2) : '—'}</span>
+        <span>y: {pose != null ? pose.translation.y.toFixed(2) : '—'}</span>
+        <span>rot: {pose != null ? pose.rotation.value.toFixed(2) : '—'} rad</span>
+      </div>
+    </ValueCard>
+  );
+}

--- a/apps/example-robot/src/main/java/frc/robot/Robot.java
+++ b/apps/example-robot/src/main/java/frc/robot/Robot.java
@@ -21,6 +21,10 @@ public class Robot extends TimedRobot {
   private DoublePublisher m_gyroPub;
   private StringSubscriber m_autoSub;
   private ProtobufPublisher<Pose2d> m_posePub;
+  private StructPublisher<Pose2d> m_poseStructPub;
+  /** Subscribes to client-published struct, echoes to PoseStructEcho for E2E verification. */
+  private StructSubscriber<Pose2d> m_poseStructFromClientSub;
+  private StructPublisher<Pose2d> m_poseStructEchoPub;
   private double m_demoTime = 0;
   private static final double kDemoFigure8ScaleX = 1.8;
   private static final double kDemoFigure8ScaleY = 1.2;
@@ -43,6 +47,15 @@ public class Robot extends TimedRobot {
     m_posePub = nt.getProtobufTopic("/MyTable/Pose", Pose2d.proto).publish();
     m_posePub.set(new Pose2d(0, 0, new Rotation2d(0)));
 
+    m_poseStructPub = nt.getStructTopic("/MyTable/PoseStruct", Pose2d.struct).publish();
+    m_poseStructPub.set(new Pose2d(0, 0, new Rotation2d(0)));
+
+    // Subscribe to client-published struct topic and echo to PoseStructEcho for E2E verification
+    m_poseStructFromClientSub =
+        nt.getStructTopic("/MyTable/PoseStructFromClient", Pose2d.struct)
+            .subscribe(new Pose2d(0, 0, new Rotation2d(0)));
+    m_poseStructEchoPub = nt.getStructTopic("/MyTable/PoseStructEcho", Pose2d.struct).publish();
+
     m_gyroPub = nt.getDoubleTopic("/MyTable/Gyro").publish();
   }
 
@@ -55,6 +68,10 @@ public class Robot extends TimedRobot {
    */
   @Override
   public void robotPeriodic() {
+    // Echo client-published struct values to PoseStructEcho for E2E verification
+    for (Pose2d received : m_poseStructFromClientSub.readQueueValues()) {
+      m_poseStructEchoPub.set(received);
+    }
   }
 
   /**
@@ -104,6 +121,7 @@ public class Robot extends TimedRobot {
     m_xPub.set(0);
     m_yPub.set(0);
     m_posePub.set(new Pose2d(0, 0, new Rotation2d(0)));
+    m_poseStructPub.set(new Pose2d(0, 0, new Rotation2d(0)));
   }
 
   /** This function is called periodically when disabled. */
@@ -133,7 +151,9 @@ public class Robot extends TimedRobot {
     double ayWorld = -kDemoFigure8ScaleY * 4 * omega * omega * Math.sin(2 * omega * t);
 
     double thetaRad = Math.atan2(vy, vx);
-    m_posePub.set(new Pose2d(x, y, new Rotation2d(thetaRad)));
+    Pose2d pose = new Pose2d(x, y, new Rotation2d(thetaRad));
+    m_posePub.set(pose);
+    m_poseStructPub.set(pose);
 
     // Gyro: match heading in degrees (CCW positive)
     m_gyroPub.set(Math.toDegrees(thetaRad));

--- a/packages/client/src/lib/client.spec.ts
+++ b/packages/client/src/lib/client.spec.ts
@@ -115,6 +115,35 @@ describe('NetworkTables', () => {
     );
   });
 
+  it('throws when createTopic is called with struct type', () => {
+    const networkTables = NetworkTables.getInstanceByTeam(973);
+    expect(() => networkTables.createTopic('/struct/bad', [5, 'struct:Pose2d'])).toThrow(
+      "Struct types are not allowed in createTopic. Use createStructTopic('/struct/bad', options) instead for proper encoding/decoding support."
+    );
+  });
+
+  it('creates a struct topic', () => {
+    const networkTables = NetworkTables.getInstanceByTeam(973);
+    const topic = networkTables.createStructTopic<{ x: number; y: number }>('/struct/pose', {
+      typeName: 'Translation2d',
+    });
+    expect(topic).toBeDefined();
+    expect(topic.getValue()).toBeNull();
+  });
+
+  it('returns existing struct topic with options applied on subsequent createStructTopic calls', () => {
+    const networkTables = NetworkTables.getInstanceByTeam(973);
+    const topic1 = networkTables.createStructTopic<{ x: number; y: number }>('/struct/reuse', {
+      typeName: 'Translation2d',
+    });
+    const topic2 = networkTables.createStructTopic<{ x: number; y: number }>('/struct/reuse', {
+      typeName: 'Translation2d',
+      defaultValue: { x: 1, y: 2 },
+    });
+    expect(topic2).toBe(topic1);
+    expect(topic2.getValue()).toEqual({ x: 1, y: 2 });
+  });
+
   it('setLogLevel sets global log level', () => {
     NetworkTables.setLogLevel(LogLevel.DEBUG);
     expect(NetworkTables.getModuleLogLevel('default')).toBe(LogLevel.DEBUG);

--- a/packages/client/src/lib/client.spec.ts
+++ b/packages/client/src/lib/client.spec.ts
@@ -144,6 +144,24 @@ describe('NetworkTables', () => {
     expect(topic2.getValue()).toEqual({ x: 1, y: 2 });
   });
 
+  it('creates struct topic with array type (Translation2d[]) and getValue/setValue work', () => {
+    const networkTables = NetworkTables.getInstanceByTeam(973);
+    const topic = networkTables.createStructTopic<Array<{ x: number; y: number }>>('/struct/arr', {
+      typeName: 'Translation2d[]',
+    });
+    expect(topic).toBeDefined();
+    expect(topic.getValue()).toBeNull();
+    expect(topic.typeInfo[1]).toBe('struct:Translation2d[]');
+    topic['_pubuid'] = 1;
+    topic['_publisher'] = true;
+    const arr = [
+      { x: 1.0, y: 2.0 },
+      { x: 3.0, y: 4.0 },
+    ];
+    topic.setValue(arr);
+    expect(topic.getValue()).toEqual(arr);
+  });
+
   it('setLogLevel sets global log level', () => {
     NetworkTables.setLogLevel(LogLevel.DEBUG);
     expect(NetworkTables.getModuleLogLevel('default')).toBe(LogLevel.DEBUG);

--- a/packages/client/src/lib/client.ts
+++ b/packages/client/src/lib/client.ts
@@ -253,7 +253,7 @@ export class NetworkTables {
    * which loses precision beyond ±2^53 (`Number.MAX_SAFE_INTEGER`). No built-in WPILib
    * struct types are affected — they all use `double`.
    */
-  createStructTopic<T extends Record<string, unknown>>(
+  createStructTopic<T extends Record<string, unknown> | Record<string, unknown>[]>(
     name: string,
     options?: {
       typeName?: string;

--- a/packages/client/src/lib/client.ts
+++ b/packages/client/src/lib/client.ts
@@ -1,5 +1,6 @@
 import { NetworkTablesPrefixTopic } from './pubsub/prefix-topic';
 import { NetworkTablesProtobufTopic } from './pubsub/protobuf-topic';
+import { NetworkTablesStructTopic } from './pubsub/struct-topic';
 import { PubSubClient } from './pubsub/pubsub';
 import { NetworkTablesTopic } from './pubsub/topic';
 import { NetworkTablesTypeInfos } from './types/types';
@@ -204,6 +205,11 @@ export class NetworkTables {
         `Protobuf types are not allowed in createTopic. Use createProtobufTopic('${name}', options) instead for proper encoding/decoding support.`
       );
     }
+    if (typeof typeInfo[1] === 'string' && typeInfo[1].startsWith('struct:')) {
+      throw new Error(
+        `Struct types are not allowed in createTopic. Use createStructTopic('${name}', options) instead for proper encoding/decoding support.`
+      );
+    }
     defaultLogger.debug('Topic created', { topicName: name, type: typeInfo[1] });
     return new NetworkTablesTopic<T>(this._client, name, typeInfo, defaultValue);
   }
@@ -235,6 +241,46 @@ export class NetworkTables {
       return existingTopic as NetworkTablesProtobufTopic<T>;
     }
     return new NetworkTablesProtobufTopic<T>(this._client, name, options);
+  }
+
+  /**
+   * Creates a new struct topic.
+   * @param name - The name of the topic.
+   * @param options - Optional typeName, schema, defaultValue, validator.
+   * @returns The struct topic. If a topic with the same name already exists (from a previous createStructTopic),
+   * the existing topic is returned and options are applied.
+   * @remarks Struct fields using `int64` or `uint64` are returned as JavaScript `number`,
+   * which loses precision beyond ±2^53 (`Number.MAX_SAFE_INTEGER`). No built-in WPILib
+   * struct types are affected — they all use `double`.
+   */
+  createStructTopic<T extends Record<string, unknown>>(
+    name: string,
+    options?: {
+      typeName?: string;
+      schema?: string;
+      defaultValue?: T;
+      validator?: z.ZodSchema<T>;
+    }
+  ): NetworkTablesStructTopic<T> {
+    const existingTopic = this._client.getTopicFromName(name);
+    if (existingTopic instanceof NetworkTablesStructTopic) {
+      if (options?.typeName) {
+        const requestedBase = options.typeName.replace(/\[\]$/, '');
+        const existingType = (existingTopic as NetworkTablesStructTopic<T>).typeInfo[1];
+        const requestedPlain = `struct:${requestedBase}`;
+        const requestedArray = `struct:${requestedBase}[]`;
+        if (existingType !== requestedPlain && existingType !== requestedArray) {
+          defaultLogger.warn('createStructTopic: typeName mismatch on reuse', {
+            topicName: name,
+            existingType,
+            requestedTypeName: options.typeName,
+          });
+        }
+      }
+      (existingTopic as NetworkTablesStructTopic<T>).applyOptions(options);
+      return existingTopic as NetworkTablesStructTopic<T>;
+    }
+    return new NetworkTablesStructTopic<T>(this._client, name, options);
   }
 
   /**

--- a/packages/client/src/lib/client.ts
+++ b/packages/client/src/lib/client.ts
@@ -270,11 +270,11 @@ export class NetworkTables {
         const requestedPlain = `struct:${requestedBase}`;
         const requestedArray = `struct:${requestedBase}[]`;
         if (existingType !== requestedPlain && existingType !== requestedArray) {
-          defaultLogger.warn('createStructTopic: typeName mismatch on reuse', {
-            topicName: name,
-            existingType,
-            requestedTypeName: options.typeName,
-          });
+          throw new Error(
+            `createStructTopic: type mismatch for topic "${name}". ` +
+              `Existing type "${existingType}" does not match requested typeName "${options.typeName}". ` +
+              `A struct topic's type is immutable once created.`
+          );
         }
       }
       (existingTopic as NetworkTablesStructTopic<T>).applyOptions(options);

--- a/packages/client/src/lib/pubsub/index.ts
+++ b/packages/client/src/lib/pubsub/index.ts
@@ -1,2 +1,3 @@
 export * from './prefix-topic';
 export * from './topic';
+export * from './struct-topic';

--- a/packages/client/src/lib/pubsub/prefix-topic.ts
+++ b/packages/client/src/lib/pubsub/prefix-topic.ts
@@ -25,7 +25,7 @@ export class NetworkTablesPrefixTopic extends NetworkTablesBaseTopic<NetworkTabl
 
     const existingTopic = this.client.getPrefixTopicFromName(name);
     if (existingTopic) {
-      pubsubLogger.info('Existing prefix topic reused', { prefix: name });
+      pubsubLogger.debug('Existing prefix topic reused', { prefix: name });
       return existingTopic;
     }
 

--- a/packages/client/src/lib/pubsub/protobuf-schema-manager.ts
+++ b/packages/client/src/lib/pubsub/protobuf-schema-manager.ts
@@ -231,7 +231,7 @@ export class ProtobufSchemaManager {
       const detectedMessageName = messageName || this.getMessageNameFromProto(root);
 
       // Create or get the schema topic (as raw/ArrayBuffer type for internal use)
-      let schemaTopic = this.client.getTopicFromName(schemaTopicName) as NetworkTablesTopic<Uint8Array> | null;
+      let schemaTopic = this.client.getTopicFromName<Uint8Array>(schemaTopicName);
       if (!schemaTopic) {
         schemaTopic = new NetworkTablesTopic<Uint8Array>(
           this.client,

--- a/packages/client/src/lib/pubsub/protobuf-topic.ts
+++ b/packages/client/src/lib/pubsub/protobuf-topic.ts
@@ -289,8 +289,8 @@ export class NetworkTablesProtobufTopic<T extends object> extends NetworkTablesT
         name: this.name,
         id: -1,
         type: this.typeInfo[1],
-        properties: this['_publishProperties'] ?? {},
-        ...(this['_pubuid'] != null ? { pubuid: this['_pubuid'] } : {}),
+        properties: this._publishProperties ?? {},
+        ...(this._pubuid != null ? { pubuid: this._pubuid } : {}),
       } as AnnounceMessageParams);
     // Type assertion needed because base class expects Uint8Array but we provide T
     // @ts-expect-error - Type mismatch is intentional: we decode Uint8Array to T before calling callbacks
@@ -339,8 +339,8 @@ export class NetworkTablesProtobufTopic<T extends object> extends NetworkTablesT
       // Get or generate pubuid
       const pubuid = id ?? this.client.messenger.getNextPubUID();
 
-      this['_pubuid'] = pubuid;
-      this['_publishProperties'] = properties;
+      this._pubuid = pubuid;
+      this._publishProperties = properties;
       pubsubLogger.debug('Topic published', { topicName: this.name, pubuid, properties, type: typeString });
 
       // Publish with the correct type string using messenger directly

--- a/packages/client/src/lib/pubsub/pubsub.ts
+++ b/packages/client/src/lib/pubsub/pubsub.ts
@@ -10,6 +10,7 @@ import {
 import { pubsubLogger } from '../util/logger';
 
 import { ProtobufSchemaManager } from './protobuf-schema-manager';
+import { StructSchemaManager } from '../struct/struct-schema-manager';
 
 import type { NetworkTablesBaseTopic } from './base-topic';
 import type { NetworkTablesPrefixTopic } from './prefix-topic';
@@ -25,6 +26,7 @@ export class PubSubClient {
   /** Value updates that arrived before the topic announcement (topicId -> latest message). Flushed when announce arrives. */
   private readonly pendingValueUpdates: Map<number, BinaryMessageData>;
   private readonly _protobufSchemaManager: ProtobufSchemaManager;
+  private readonly _structSchemaManager: StructSchemaManager;
   private static _instances = new Map<string, PubSubClient>();
   // Unified in-flight operations tracking (schema registrations and topic publishes)
   private readonly inFlightOperations = new Map<string, Promise<unknown>>();
@@ -36,6 +38,10 @@ export class PubSubClient {
 
   get protobufSchemaManager() {
     return this._protobufSchemaManager;
+  }
+
+  get structSchemaManager() {
+    return this._structSchemaManager;
   }
 
   private constructor(serverUrl: string) {
@@ -51,6 +57,7 @@ export class PubSubClient {
     this.knownTopicParams = new Map();
     this.pendingValueUpdates = new Map();
     this._protobufSchemaManager = new ProtobufSchemaManager(this);
+    this._structSchemaManager = new StructSchemaManager(this);
 
     // When the connection drops, local server-side announcement state is no longer reliable.
     // Clear known ids so outgoing updates can be safely queued until re-announced.

--- a/packages/client/src/lib/pubsub/pubsub.ts
+++ b/packages/client/src/lib/pubsub/pubsub.ts
@@ -81,7 +81,7 @@ export class PubSubClient {
         });
         return;
       }
-      pubsubLogger.info('Socket disconnected; clearing announcement state', {
+      pubsubLogger.debug('Socket disconnected; clearing announcement state', {
         topicCount: this.topics.size,
         prefixTopicCount: this.prefixTopics.size,
         knownTopicParams: this.knownTopicParams.size,

--- a/packages/client/src/lib/pubsub/pubsub.ts
+++ b/packages/client/src/lib/pubsub/pubsub.ts
@@ -433,11 +433,11 @@ export class PubSubClient {
    * @param topicId - The ID of the topic to get.
    * @returns The topic with the given ID, or null if no topic with that ID exists.
    */
-  private getTopicFromId(topicId: number): NetworkTablesTopic<NetworkTablesTypes> | null {
+  private getTopicFromId<T extends NetworkTablesTypes>(topicId: number): NetworkTablesTopic<T> | null {
     for (const topic of this.topics.values()) {
       if (topic.id === topicId) {
         pubsubLogger.debug('Topic found by ID', { topicId, topicName: topic.name });
-        return topic;
+        return topic as unknown as NetworkTablesTopic<T>;
       }
     }
 
@@ -450,14 +450,14 @@ export class PubSubClient {
    * @param topicName - The name of the topic to get.
    * @returns The topic with the given name, or null if no topic with that name exists.
    */
-  getTopicFromName(topicName: string) {
-    const topic = this.topics.get(topicName) ?? null;
+  getTopicFromName<T extends NetworkTablesTypes>(topicName: string): NetworkTablesTopic<T> | null {
+    const topic = this.topics.get(topicName);
     if (topic) {
       pubsubLogger.debug('Topic found by name', { topicName });
-    } else {
-      pubsubLogger.debug('Topic not found by name', { topicName });
+      return topic as unknown as NetworkTablesTopic<T>;
     }
-    return topic;
+    pubsubLogger.debug('Topic not found by name', { topicName });
+    return null;
   }
 
   /**

--- a/packages/client/src/lib/pubsub/struct-topic.spec.ts
+++ b/packages/client/src/lib/pubsub/struct-topic.spec.ts
@@ -96,6 +96,20 @@ describe('NetworkTablesStructTopic', () => {
     ]);
   });
 
+  it('setValue on array struct topic throws clear error when given non-array', () => {
+    const topic = new NetworkTablesStructTopic<Array<{ x: number; y: number }>>(client, '/struct/arr', {
+      typeName: 'Translation2d[]',
+    });
+    topic['_pubuid'] = 1;
+    topic['_publisher'] = true;
+    expect(() => topic.setValue({ x: 1, y: 2 } as unknown as Array<{ x: number; y: number }>)).toThrow(
+      /Expected an array for array struct topic \/struct\/arr, got object/
+    );
+    expect(() => topic.setValue(null as unknown as Array<{ x: number; y: number }>)).toThrow(
+      /Expected an array for array struct topic \/struct\/arr, got object \(null\)/
+    );
+  });
+
   it('schema option builds descriptor and enables publish', () => {
     const topic = new NetworkTablesStructTopic<{ x: number; y: number }>(client, '/struct/custom', {
       typeName: 'Custom2d',

--- a/packages/client/src/lib/pubsub/struct-topic.spec.ts
+++ b/packages/client/src/lib/pubsub/struct-topic.spec.ts
@@ -16,7 +16,7 @@ describe('NetworkTablesStructTopic', () => {
 
   beforeEach(() => {
     client['topics'].clear();
-    client['prefixTopics'].clear();
+    // Do not clear prefixTopics: StructSchemaManager's prefix (/.schema/struct:) is needed for deferred-schema test
     client['knownTopicParams'].clear();
     client['pendingValueUpdates'].clear();
     client.structSchemaManager.clearCache();
@@ -106,5 +106,61 @@ describe('NetworkTablesStructTopic', () => {
     topic.setValue({ x: 10, y: 20 });
     expect(topic.getValue()).toEqual({ x: 10, y: 20 });
     expect(topic.typeInfo[1]).toBe('struct:Custom2d');
+  });
+
+  describe('applyOptions', () => {
+    it('applies typeName and schema when reusing topic', () => {
+      const topic = new NetworkTablesStructTopic<{ x: number; y: number }>(client, '/struct/apply', {
+        typeName: 'Translation2d',
+      });
+      expect(topic.getValue()).toBeNull();
+      topic.applyOptions({
+        typeName: 'CustomPoint',
+        schema: 'double x;double y',
+        defaultValue: { x: 1, y: 2 },
+      });
+      expect(topic.getValue()).toEqual({ x: 1, y: 2 });
+      topic['_pubuid'] = 1;
+      topic['_publisher'] = true;
+      topic.setValue({ x: 5, y: 10 });
+      expect(topic.getValue()).toEqual({ x: 5, y: 10 });
+    });
+
+    it('applies schema only (keeps typeName), builds descriptor', () => {
+      const topic = new NetworkTablesStructTopic<{ a: number; b: number }>(client, '/struct/schemaOnly', {
+        typeName: 'AB',
+      });
+      topic.applyOptions({ schema: 'double a;double b' });
+      topic['_pubuid'] = 1;
+      topic['_publisher'] = true;
+      topic.setValue({ a: 3, b: 4 });
+      expect(topic.getValue()).toEqual({ a: 3, b: 4 });
+    });
+  });
+
+  describe('deferred schema (pending schema retry in ensureDescriptor)', () => {
+    it('stores schema when build fails (nested not available), retries on setValue after schema arrives', () => {
+      const topic = new NetworkTablesStructTopic<{ f: { x: number } }>(client, '/struct/deferred', {
+        typeName: 'Outer',
+        schema: 'NestedT f',
+      });
+      expect(topic['_descriptor']).toBeNull();
+      expect(topic['_pendingSchema']).toBe('NestedT f');
+
+      const prefixTopic = client.getPrefixTopicFromName('/.schema/struct:');
+      if (!prefixTopic) throw new Error('expected prefix topic');
+      prefixTopic.updateValue(
+        { name: '/.schema/struct:NestedT', id: 1, type: 'structschema', properties: {} },
+        new TextEncoder().encode('double x'),
+        0
+      );
+
+      topic['_pubuid'] = 1;
+      topic['_publisher'] = true;
+      topic.setValue({ f: { x: 42 } });
+      expect(topic['_descriptor']).not.toBeNull();
+      expect(topic['_pendingSchema']).toBeNull();
+      expect(topic.getValue()).toEqual({ f: { x: 42 } });
+    });
   });
 });

--- a/packages/client/src/lib/pubsub/struct-topic.spec.ts
+++ b/packages/client/src/lib/pubsub/struct-topic.spec.ts
@@ -1,0 +1,110 @@
+import WSMock from 'vitest-websocket-mock';
+
+import { PubSubClient } from './pubsub';
+import { NetworkTablesStructTopic } from './struct-topic';
+
+const serverUrl = 'ws://localhost:5814/nt/9999';
+
+describe('NetworkTablesStructTopic', () => {
+  let client: PubSubClient;
+
+  beforeAll(async () => {
+    const server = new WSMock(serverUrl);
+    client = PubSubClient.getInstance(serverUrl);
+    await server.connected;
+  });
+
+  beforeEach(() => {
+    client['topics'].clear();
+    client['prefixTopics'].clear();
+    client['knownTopicParams'].clear();
+    client['pendingValueUpdates'].clear();
+    client.structSchemaManager.clearCache();
+  });
+
+  it('constructor creates topic with typeName', () => {
+    const topic = new NetworkTablesStructTopic<{ x: number; y: number }>(client, '/struct/t', {
+      typeName: 'Translation2d',
+    });
+    expect(topic).toBeDefined();
+    expect(topic.typeInfo[1]).toBe('struct:Translation2d');
+  });
+
+  it('getValue returns null initially', () => {
+    const topic = new NetworkTablesStructTopic<{ x: number; y: number }>(client, '/struct/t', {
+      typeName: 'Translation2d',
+    });
+    expect(topic.getValue()).toBeNull();
+  });
+
+  it('updateValue decodes bytes and getValue returns decoded value', () => {
+    const topic = new NetworkTablesStructTopic<{ x: number; y: number }>(client, '/struct/t', {
+      typeName: 'Translation2d',
+    });
+    const buf = new ArrayBuffer(16);
+    const view = new DataView(buf);
+    view.setFloat64(0, 1.5, true);
+    view.setFloat64(8, -2.25, true);
+    topic.updateValue(new Uint8Array(buf), 0);
+    expect(topic.getValue()).toEqual({ x: 1.5, y: -2.25 });
+  });
+
+  it('setValue encodes and publishes when schema available', () => {
+    const topic = new NetworkTablesStructTopic<{ x: number; y: number }>(client, '/struct/t', {
+      typeName: 'Translation2d',
+    });
+    topic['_pubuid'] = 1;
+    topic['_publisher'] = true;
+    topic.setValue({ x: 3, y: 4 });
+    expect(topic.getValue()).toEqual({ x: 3, y: 4 });
+  });
+
+  it('returns existing topic when createStructTopic called again with same name', () => {
+    const topic1 = new NetworkTablesStructTopic<{ x: number }>(client, '/struct/same', {
+      typeName: 'Rotation2d',
+    });
+    const existing = client.getTopicFromName('/struct/same');
+    expect(existing).toBe(topic1);
+  });
+
+  it('struct:TypeName[] array topic decodes and encodes array of structs', () => {
+    const topic = new NetworkTablesStructTopic<Array<{ x: number; y: number }>>(client, '/struct/arr', {
+      typeName: 'Translation2d[]',
+    });
+    // Pack 2 Translation2d: 16 bytes each = 32 bytes total
+    const buf = new ArrayBuffer(32);
+    const view = new DataView(buf);
+    view.setFloat64(0, 1.0, true);
+    view.setFloat64(8, 2.0, true);
+    view.setFloat64(16, 3.0, true);
+    view.setFloat64(24, 4.0, true);
+    topic.updateValue(new Uint8Array(buf), 0);
+    expect(topic.getValue()).toEqual([
+      { x: 1.0, y: 2.0 },
+      { x: 3.0, y: 4.0 },
+    ]);
+
+    topic['_pubuid'] = 1;
+    topic['_publisher'] = true;
+    topic.setValue([
+      { x: 5.0, y: 6.0 },
+      { x: 7.0, y: 8.0 },
+    ]);
+    expect(topic.getValue()).toEqual([
+      { x: 5.0, y: 6.0 },
+      { x: 7.0, y: 8.0 },
+    ]);
+  });
+
+  it('schema option builds descriptor and enables publish', () => {
+    const topic = new NetworkTablesStructTopic<{ x: number; y: number }>(client, '/struct/custom', {
+      typeName: 'Custom2d',
+      schema: 'double x;double y',
+    });
+    topic['_pubuid'] = 1;
+    topic['_publisher'] = true;
+    topic.setValue({ x: 10, y: 20 });
+    expect(topic.getValue()).toEqual({ x: 10, y: 20 });
+    expect(topic.typeInfo[1]).toBe('struct:Custom2d');
+  });
+});

--- a/packages/client/src/lib/pubsub/struct-topic.ts
+++ b/packages/client/src/lib/pubsub/struct-topic.ts
@@ -1,0 +1,194 @@
+import {
+  type AnnounceMessage,
+  type AnnounceMessageParams,
+  type PublishMessageParams,
+  type SubscribeOptions,
+  type TopicProperties,
+} from '../types/types';
+
+import { pubsubLogger } from '../util/logger';
+
+import { NetworkTablesTopic } from './topic';
+
+import type { CallbackFn } from './base-topic';
+import type { PubSubClient } from './pubsub';
+import type { z } from 'zod';
+import type { StructDescriptor } from '../struct/struct-descriptor';
+import { pack, unpack, type StructPlainObject } from '../struct/struct-codec';
+import { getBuiltInDescriptor } from '../struct/built-in-schemas';
+import { parseSchema, buildStructDescriptor } from '../struct/struct-parser';
+
+function structTypeInfo(typeName: string, isArray: boolean): [5, string] {
+  return [5, isArray ? `struct:${typeName}[]` : `struct:${typeName}`];
+}
+
+export class NetworkTablesStructTopic<
+  T extends StructPlainObject | StructPlainObject[],
+> extends NetworkTablesTopic<Uint8Array> {
+  private decodedValue: T | null = null;
+  private _typeName: string;
+  private _isArray: boolean;
+  private _validator?: z.ZodSchema<T>;
+  private _descriptor: StructDescriptor | null = null;
+
+  constructor(
+    client: PubSubClient,
+    name: string,
+    options?: {
+      typeName?: string;
+      schema?: string;
+      defaultValue?: T;
+      validator?: z.ZodSchema<T>;
+    }
+  ) {
+    const typeName = options?.typeName ?? '';
+    const isArray = typeName.endsWith('[]');
+    const baseTypeName = isArray ? typeName.slice(0, -2) : typeName;
+    super(client, name, structTypeInfo(baseTypeName || 'Unknown', isArray), undefined);
+    this._typeName = baseTypeName || typeName;
+    this._isArray = isArray;
+    this._validator = options?.validator;
+    if (options?.defaultValue !== undefined) {
+      this.decodedValue = options.defaultValue;
+    }
+    if (options?.schema) {
+      try {
+        const fields = parseSchema(options.schema);
+        const getNested = (n: string) => client.structSchemaManager.fetchDescriptor(n);
+        this._descriptor = buildStructDescriptor(this._typeName, fields, getNested);
+      } catch (err) {
+        pubsubLogger.debug('Deferred struct descriptor build from schema option', { topicName: name, error: err });
+      }
+    }
+    if (!this._descriptor && this._typeName) {
+      this._descriptor = getBuiltInDescriptor(this._typeName) ?? null;
+    }
+  }
+
+  applyOptions(options?: { typeName?: string; schema?: string; defaultValue?: T; validator?: z.ZodSchema<T> }): void {
+    if (options?.validator !== undefined) this._validator = options.validator;
+    if (options?.defaultValue !== undefined) this.decodedValue = options.defaultValue;
+  }
+
+  private ensureDescriptor(): StructDescriptor {
+    if (this._descriptor) return this._descriptor;
+    const d = this.client.structSchemaManager.fetchDescriptor(this._typeName);
+    if (d) {
+      this._descriptor = d;
+      return d;
+    }
+    throw new Error(`Struct descriptor not found for type "${this._typeName}"`);
+  }
+
+  private maybeValidate<V>(value: V): T {
+    return (this._validator ? this._validator.parse(value) : value) as T;
+  }
+
+  // @ts-expect-error - Base returns Uint8Array; we return decoded T
+  override getValue(): T | null {
+    return this.decodedValue;
+  }
+
+  // @ts-expect-error - Base expects Uint8Array; we accept T and encode
+  override setValue(value: T): void {
+    const validated = this.maybeValidate(value);
+    this.decodedValue = validated;
+    const encoded = this.encodeValue(validated);
+    super.setValue(encoded);
+  }
+
+  private decodeValue(value: Uint8Array): T | null {
+    try {
+      const desc = this.ensureDescriptor();
+      if (this._isArray) {
+        const elemSize = desc.size;
+        const n = value.length / elemSize;
+        const arr: StructPlainObject[] = [];
+        for (let i = 0; i < n; i++) {
+          arr.push(unpack(new Uint8Array(value.buffer, value.byteOffset + i * elemSize, elemSize), desc));
+        }
+        return this.maybeValidate(arr);
+      }
+      const out = unpack(value, desc);
+      return this.maybeValidate(out);
+    } catch (err) {
+      pubsubLogger.debug('Failed to decode struct value', { topicName: this.name, error: err });
+      return null;
+    }
+  }
+
+  private encodeValue(value: T): Uint8Array {
+    const desc = this.ensureDescriptor();
+    if (this._isArray) {
+      const arr = value as unknown as StructPlainObject[];
+      const elemSize = desc.size;
+      const buf = new Uint8Array(arr.length * elemSize);
+      for (let i = 0; i < arr.length; i++) {
+        buf.set(pack(arr[i] as StructPlainObject, desc), i * elemSize);
+      }
+      return buf;
+    }
+    return pack(value as StructPlainObject, desc);
+  }
+
+  override updateValue(value: Uint8Array, lastChangedTime: number): void {
+    this.decodedValue = this.decodeValue(value);
+    super.updateValue(value, lastChangedTime);
+  }
+
+  override announce(params: AnnounceMessageParams): void {
+    super.announce(params);
+    const typeString = params.type;
+    if (!this.name.startsWith('/.schema/') && typeString.startsWith('struct:')) {
+      const suffix = typeString.slice(7);
+      this._isArray = suffix.endsWith('[]');
+      this._typeName = this._isArray ? suffix.slice(0, -2) : suffix;
+      this._descriptor = this.client.structSchemaManager.fetchDescriptor(this._typeName) ?? this._descriptor;
+    }
+  }
+
+  // Override to accept callback with decoded T; we pass decoded value in notifySubscribers
+  // @ts-expect-error - Base expects CallbackFn<Uint8Array>; we accept (T | null, params) => void
+  override subscribe(
+    callback: (value: T | null, params: AnnounceMessageParams) => void,
+    options: Omit<SubscribeOptions, 'prefix'> = {},
+    id?: number,
+    save = true
+  ): number {
+    return super.subscribe(callback as CallbackFn<Uint8Array>, options, id, save);
+  }
+
+  override notifySubscribers(): void {
+    const params =
+      this._announceParams ??
+      ({
+        name: this.name,
+        id: -1,
+        type: this.typeInfo[1],
+        properties: this._publishProperties ?? {},
+        ...(this._pubuid != null ? { pubuid: this._pubuid } : {}),
+      } as AnnounceMessageParams);
+    this.subscribers.forEach((info) =>
+      (info.callback as (value: T | null, params: AnnounceMessageParams) => void)(this.decodedValue, params)
+    );
+  }
+
+  override async publish(properties: TopicProperties = {}, id?: number): Promise<AnnounceMessage | void> {
+    const operationKey = `publish:${this.name}`;
+    return this.client.getOrCreateInFlightOperation(operationKey, async () => {
+      if (this.publisher) {
+        pubsubLogger.debug('Publish skipped', { topicName: this.name, reason: 'already publisher' });
+        return;
+      }
+      const desc = this.ensureDescriptor();
+      await this.client.structSchemaManager.addSchema(desc);
+      const typeString = this._isArray ? `struct:${this._typeName}[]` : `struct:${this._typeName}`;
+      const pubuid = id ?? this.client.messenger.getNextPubUID();
+      this._pubuid = pubuid;
+      this._publishProperties = properties;
+      pubsubLogger.debug('Topic published', { topicName: this.name, pubuid, properties, type: typeString });
+      const publishParams: PublishMessageParams = { type: typeString, name: this.name, pubuid, properties };
+      return await this.client.messenger.publish(publishParams);
+    });
+  }
+}

--- a/packages/client/src/lib/pubsub/struct-topic.ts
+++ b/packages/client/src/lib/pubsub/struct-topic.ts
@@ -92,9 +92,9 @@ export class NetworkTablesStructTopic<
   // @ts-expect-error - Base expects Uint8Array; we accept T and encode
   override setValue(value: T): void {
     const validated = this.maybeValidate(value);
-    this.decodedValue = validated;
     const encoded = this.encodeValue(validated);
     super.setValue(encoded);
+    this.decodedValue = validated;
   }
 
   private decodeValue(value: Uint8Array): T | null {
@@ -102,6 +102,7 @@ export class NetworkTablesStructTopic<
       const desc = this.ensureDescriptor();
       if (this._isArray) {
         const elemSize = desc.size;
+        if (value.length % elemSize !== 0) return null;
         const n = value.length / elemSize;
         const arr: StructPlainObject[] = [];
         for (let i = 0; i < n; i++) {

--- a/packages/client/src/lib/pubsub/struct-topic.ts
+++ b/packages/client/src/lib/pubsub/struct-topic.ts
@@ -144,8 +144,8 @@ export class NetworkTablesStructTopic<
   override setValue(value: T): void {
     const validated = this.maybeValidate(value);
     const encoded = this.encodeValue(validated);
-    super.setValue(encoded);
     this.decodedValue = validated;
+    super.setValue(encoded);
   }
 
   private decodeValue(value: Uint8Array): T | null {

--- a/packages/client/src/lib/pubsub/struct-topic.ts
+++ b/packages/client/src/lib/pubsub/struct-topic.ts
@@ -30,6 +30,8 @@ export class NetworkTablesStructTopic<
   private _isArray: boolean;
   private _validator?: z.ZodSchema<T>;
   private _descriptor: StructDescriptor | null = null;
+  /** When schema option build fails (e.g. nested not yet available), store and retry in ensureDescriptor. */
+  private _pendingSchema: string | null = null;
 
   constructor(
     client: PubSubClient,
@@ -58,6 +60,7 @@ export class NetworkTablesStructTopic<
         this._descriptor = buildStructDescriptor(this._typeName, fields, getNested);
       } catch (err) {
         pubsubLogger.debug('Deferred struct descriptor build from schema option', { topicName: name, error: err });
+        this._pendingSchema = options.schema;
       }
     }
     if (!this._descriptor && this._typeName) {
@@ -66,12 +69,60 @@ export class NetworkTablesStructTopic<
   }
 
   applyOptions(options?: { typeName?: string; schema?: string; defaultValue?: T; validator?: z.ZodSchema<T> }): void {
-    if (options?.validator !== undefined) this._validator = options.validator;
-    if (options?.defaultValue !== undefined) this.decodedValue = options.defaultValue;
+    if (!options) return;
+    if (options.typeName !== undefined) {
+      const typeName = options.typeName;
+      const isArray = typeName.endsWith('[]');
+      const baseTypeName = isArray ? typeName.slice(0, -2) : typeName;
+      this._typeName = baseTypeName || typeName;
+      this._isArray = isArray;
+      this._descriptor = null;
+      this._pendingSchema = null;
+    }
+    if (options.schema !== undefined) {
+      const schema = options.schema;
+      this._pendingSchema = schema || null;
+      if (schema) {
+        try {
+          const fields = parseSchema(schema);
+          const getNested = (n: string) => this.client.structSchemaManager.fetchDescriptor(n);
+          this._descriptor = buildStructDescriptor(this._typeName, fields, getNested);
+          this._pendingSchema = null;
+        } catch (err) {
+          pubsubLogger.debug('Deferred struct descriptor build from schema option (applyOptions)', {
+            topicName: this.name,
+            error: err,
+          });
+          this._descriptor = null;
+        }
+      } else {
+        this._descriptor = null;
+      }
+    }
+    if (!this._descriptor && this._typeName) {
+      this._descriptor = getBuiltInDescriptor(this._typeName) ?? null;
+    }
+    if (options.validator !== undefined) this._validator = options.validator;
+    if (options.defaultValue !== undefined) this.decodedValue = options.defaultValue;
   }
 
   private ensureDescriptor(): StructDescriptor {
     if (this._descriptor) return this._descriptor;
+    const schemaToTry = this._pendingSchema;
+    if (schemaToTry) {
+      try {
+        const fields = parseSchema(schemaToTry);
+        const getNested = (n: string) => this.client.structSchemaManager.fetchDescriptor(n);
+        this._descriptor = buildStructDescriptor(this._typeName, fields, getNested);
+        this._pendingSchema = null;
+        return this._descriptor;
+      } catch (err) {
+        pubsubLogger.debug('Retry struct descriptor from pending schema failed', {
+          topicName: this.name,
+          error: err,
+        });
+      }
+    }
     const d = this.client.structSchemaManager.fetchDescriptor(this._typeName);
     if (d) {
       this._descriptor = d;

--- a/packages/client/src/lib/pubsub/struct-topic.ts
+++ b/packages/client/src/lib/pubsub/struct-topic.ts
@@ -172,6 +172,11 @@ export class NetworkTablesStructTopic<
   private encodeValue(value: T): Uint8Array {
     const desc = this.ensureDescriptor();
     if (this._isArray) {
+      if (!Array.isArray(value)) {
+        throw new Error(
+          `Expected an array for array struct topic ${this.name}, got ${typeof value}${value === null ? ' (null)' : value === undefined ? ' (undefined)' : ''}`
+        );
+      }
       const arr = value as unknown as StructPlainObject[];
       const elemSize = desc.size;
       const buf = new Uint8Array(arr.length * elemSize);

--- a/packages/client/src/lib/pubsub/topic.ts
+++ b/packages/client/src/lib/pubsub/topic.ts
@@ -19,9 +19,9 @@ export class NetworkTablesTopic<T extends NetworkTablesTypes> extends NetworkTab
   readonly type = 'regular';
   private value: T | null;
   private readonly _typeInfo: NetworkTablesTypeInfo;
-  private _publisher: boolean;
-  private _pubuid?: number;
-  private _publishProperties?: TopicProperties;
+  protected _publisher: boolean;
+  protected _pubuid?: number;
+  protected _publishProperties?: TopicProperties;
 
   /**
    * Gets the type info for the topic.

--- a/packages/client/src/lib/pubsub/topic.ts
+++ b/packages/client/src/lib/pubsub/topic.ts
@@ -61,12 +61,12 @@ export class NetworkTablesTopic<T extends NetworkTablesTypes> extends NetworkTab
     this.value = defaultValue ?? null;
     this._publisher = false;
 
-    const existingTopic = this.client.getTopicFromName(name);
+    const existingTopic = this.client.getTopicFromName<T>(name);
     if (existingTopic) {
       if (existingTopic.typeInfo[0] === typeInfo[0] && existingTopic.typeInfo[1] === typeInfo[1]) {
         pubsubLogger.debug('Existing topic reused', { topicName: name, type: typeInfo[1] });
         // This is a valid cast because we have checked via typeInfo that the topic is of type T
-        return existingTopic as unknown as NetworkTablesTopic<T>;
+        return existingTopic;
       } else {
         pubsubLogger.debug('Type mismatch detected', {
           topicName: name,

--- a/packages/client/src/lib/pubsub/topic.ts
+++ b/packages/client/src/lib/pubsub/topic.ts
@@ -64,7 +64,7 @@ export class NetworkTablesTopic<T extends NetworkTablesTypes> extends NetworkTab
     const existingTopic = this.client.getTopicFromName(name);
     if (existingTopic) {
       if (existingTopic.typeInfo[0] === typeInfo[0] && existingTopic.typeInfo[1] === typeInfo[1]) {
-        pubsubLogger.info('Existing topic reused', { topicName: name, type: typeInfo[1] });
+        pubsubLogger.debug('Existing topic reused', { topicName: name, type: typeInfo[1] });
         // This is a valid cast because we have checked via typeInfo that the topic is of type T
         return existingTopic as unknown as NetworkTablesTopic<T>;
       } else {

--- a/packages/client/src/lib/socket/socket.ts
+++ b/packages/client/src/lib/socket/socket.ts
@@ -382,8 +382,10 @@ export class NetworkTablesSocket {
 
     // Only log if it's been a while since the last connection log (close handler handles most logging)
     if (timeSinceLastLog >= NetworkTablesSocket.CONNECTION_LOG_INTERVAL) {
+      const errorMessage =
+        typeof ErrorEvent !== 'undefined' && event instanceof ErrorEvent ? event.message : 'Connection error';
       socketLogger.debug('WebSocket error occurred', {
-        error: event instanceof ErrorEvent ? event.message : 'Connection error',
+        error: errorMessage,
         note: 'Connection close details will follow',
       });
     }

--- a/packages/client/src/lib/socket/socket.ts
+++ b/packages/client/src/lib/socket/socket.ts
@@ -74,7 +74,7 @@ export class NetworkTablesSocket {
   ) {
     // Connect to the server using the provided URL
     this._websocket = new WebSocket(serverUrl, [NetworkTablesSocket.PROTOCOL_V4_1, NetworkTablesSocket.PROTOCOL_V4_0]);
-    socketLogger.info('Connection attempt started', {
+    socketLogger.debug('Connection attempt started', {
       serverUrl,
       protocols: [NetworkTablesSocket.PROTOCOL_V4_1, NetworkTablesSocket.PROTOCOL_V4_0],
       autoConnect,
@@ -489,7 +489,7 @@ export class NetworkTablesSocket {
     if (this.isConnected()) {
       const queuedCount = this.messageQueue.length;
       if (queuedCount > 0) {
-        socketLogger.info('Sending queued messages', { count: queuedCount });
+        socketLogger.debug('Sending queued messages', { count: queuedCount });
       }
       while (this.messageQueue.length > 0) {
         const message = this.messageQueue.shift();

--- a/packages/client/src/lib/struct/built-in-schemas.ts
+++ b/packages/client/src/lib/struct/built-in-schemas.ts
@@ -1,0 +1,66 @@
+import { buildStructDescriptor, parseSchema } from './struct-parser';
+import type { StructDescriptor } from './struct-descriptor';
+
+const SCHEMAS: Record<string, string> = {
+  Translation2d: 'double x;double y',
+  Rotation2d: 'double value',
+  Pose2d: 'Translation2d translation;Rotation2d rotation',
+  Transform2d: 'Translation2d translation;Rotation2d rotation',
+  Twist2d: 'double dx;double dy;double dtheta',
+  Translation3d: 'double x;double y;double z',
+  Quaternion: 'double w;double x;double y;double z',
+  Rotation3d: 'Quaternion q',
+  Pose3d: 'Translation3d translation;Rotation3d rotation',
+  Transform3d: 'Translation3d translation;Rotation3d rotation',
+  Twist3d: 'double dx;double dy;double dz;double rx;double ry;double rz',
+};
+
+const builtInDescriptors = new Map<string, StructDescriptor>();
+
+function getBuiltIn(name: string): StructDescriptor | null {
+  return builtInDescriptors.get(name) ?? null;
+}
+
+function initBuiltIns(): void {
+  const order = [
+    'Translation2d',
+    'Rotation2d',
+    'Translation3d',
+    'Quaternion',
+    'Pose2d',
+    'Transform2d',
+    'Twist2d',
+    'Rotation3d',
+    'Pose3d',
+    'Transform3d',
+    'Twist3d',
+  ];
+  for (const typeName of order) {
+    if (builtInDescriptors.has(typeName)) continue;
+    const schema = SCHEMAS[typeName];
+    if (!schema) continue;
+    const fields = parseSchema(schema);
+    const descriptor = buildStructDescriptor(typeName, fields, getBuiltIn);
+    builtInDescriptors.set(typeName, descriptor);
+  }
+}
+
+export function getBuiltInDescriptor(typeName: string): StructDescriptor | null {
+  if (builtInDescriptors.size === 0) initBuiltIns();
+  const cached = builtInDescriptors.get(typeName);
+  if (cached) return cached;
+  const schema = SCHEMAS[typeName];
+  if (!schema) return null;
+  const fields = parseSchema(schema);
+  const descriptor = buildStructDescriptor(typeName, fields, getBuiltIn);
+  builtInDescriptors.set(typeName, descriptor);
+  return descriptor;
+}
+
+/** All built-in struct type names (WPILib geometry). */
+export const BUILT_IN_STRUCT_TYPE_NAMES = Object.keys(SCHEMAS);
+
+/** Returns the schema string for a built-in type, or undefined. */
+export function getBuiltInSchemaString(typeName: string): string | undefined {
+  return SCHEMAS[typeName];
+}

--- a/packages/client/src/lib/struct/index.ts
+++ b/packages/client/src/lib/struct/index.ts
@@ -1,0 +1,11 @@
+export {
+  type StructDescriptor,
+  type StructFieldDescriptor,
+  type PrimitiveTypeName,
+  PRIMITIVE_SIZES,
+  getPrimitiveSize,
+  isPrimitiveType,
+} from './struct-descriptor';
+export { parseSchema, buildStructDescriptor, type ParsedField } from './struct-parser';
+export { pack, unpack, type StructPlainObject } from './struct-codec';
+export { getBuiltInDescriptor, BUILT_IN_STRUCT_TYPE_NAMES } from './built-in-schemas';

--- a/packages/client/src/lib/struct/struct-codec.spec.ts
+++ b/packages/client/src/lib/struct/struct-codec.spec.ts
@@ -83,6 +83,15 @@ describe('struct-codec', () => {
       expect(desc.fields[1].bitShift).toBe(0);
       expect(desc.fields[1].offset).toBe(1);
     });
+
+    it('31-bit bitfield uses correct unsigned mask (no JS overflow)', () => {
+      const fields = parseSchema('uint32 wide:31');
+      const desc = buildStructDescriptor('Wide', fields, () => null);
+      const value = { wide: 0x7fffffff };
+      const buf = pack(value, desc);
+      expect(buf.length).toBe(4);
+      expect(unpack(buf, desc)).toEqual(value);
+    });
   });
 
   describe('errors', () => {

--- a/packages/client/src/lib/struct/struct-codec.spec.ts
+++ b/packages/client/src/lib/struct/struct-codec.spec.ts
@@ -1,0 +1,103 @@
+import { pack, unpack, type StructPlainObject } from './struct-codec';
+import { getBuiltInDescriptor } from './built-in-schemas';
+import { buildStructDescriptor } from './struct-parser';
+import { parseSchema } from './struct-parser';
+
+describe('struct-codec', () => {
+  describe('round-trip', () => {
+    it('round-trip Translation2d pack then unpack', () => {
+      const desc = getBuiltInDescriptor('Translation2d');
+      expect(desc).toBeDefined();
+      const value = { x: 1.5, y: -2.25 };
+      const buf = pack(value, desc!);
+      expect(buf.length).toBe(16);
+      const back = unpack(buf, desc!);
+      expect(back).toEqual(value);
+    });
+
+    it('round-trip Pose2d (nested structs)', () => {
+      const desc = getBuiltInDescriptor('Pose2d');
+      expect(desc).toBeDefined();
+      const value = {
+        translation: { x: 1, y: 2 },
+        rotation: { value: 0.5 },
+      };
+      const buf = pack(value, desc!);
+      expect(buf.length).toBe(24);
+      const back = unpack(buf, desc!);
+      expect(back).toEqual(value);
+    });
+
+    it('little-endian byte order', () => {
+      const fields = parseSchema('int32 a');
+      const desc = buildStructDescriptor('LE', fields, () => null);
+      const buf = pack({ a: 0x01020304 }, desc);
+      expect(buf[0]).toBe(0x04);
+      expect(buf[1]).toBe(0x03);
+      expect(buf[2]).toBe(0x02);
+      expect(buf[3]).toBe(0x01);
+      expect(unpack(buf, desc)).toEqual({ a: 0x01020304 });
+    });
+  });
+
+  describe('arrays', () => {
+    it('array of primitives pack/unpack', () => {
+      const fields = parseSchema('int32 arr[4]');
+      const desc = buildStructDescriptor('Arr', fields, () => null);
+      const value = { arr: [1, 2, 3, 4] };
+      const buf = pack(value, desc);
+      expect(buf.length).toBe(16);
+      expect(unpack(buf, desc)).toEqual(value);
+    });
+  });
+
+  describe('bitfield', () => {
+    it('single bitfield pack/unpack', () => {
+      const fields = parseSchema('uint8 flags:4');
+      const desc = buildStructDescriptor('Flags', fields, () => null);
+      const value = { flags: 0b1010 };
+      const buf = pack(value, desc);
+      expect(buf.length).toBe(1);
+      expect(unpack(buf, desc)).toEqual(value);
+    });
+
+    it('consecutive same-type bitfields coalesce into one storage unit', () => {
+      const fields = parseSchema('uint8 a:4;uint8 b:4');
+      const desc = buildStructDescriptor('Packed', fields, () => null);
+      expect(desc.size).toBe(1);
+      expect(desc.fields[0].bitShift).toBe(0);
+      expect(desc.fields[1].bitShift).toBe(4);
+      const value = { a: 0b0101, b: 0b1010 };
+      const buf = pack(value, desc);
+      expect(buf.length).toBe(1);
+      expect(buf[0]).toBe(0b10100101);
+      expect(unpack(buf, desc)).toEqual(value);
+    });
+
+    it('bitfield overflow starts new storage unit', () => {
+      const fields = parseSchema('uint8 a:6;uint8 b:6');
+      const desc = buildStructDescriptor('Overflow', fields, () => null);
+      expect(desc.size).toBe(2);
+      expect(desc.fields[0].bitShift).toBe(0);
+      expect(desc.fields[0].offset).toBe(0);
+      expect(desc.fields[1].bitShift).toBe(0);
+      expect(desc.fields[1].offset).toBe(1);
+    });
+  });
+
+  describe('errors', () => {
+    it('reject buffer too small for unpack', () => {
+      const desc = getBuiltInDescriptor('Translation2d');
+      expect(desc).toBeDefined();
+      const short = new Uint8Array(8);
+      expect(() => unpack(short, desc!)).toThrow(/buffer too small/);
+    });
+
+    it('reject invalid value for pack (missing fields)', () => {
+      const desc = getBuiltInDescriptor('Translation2d');
+      expect(desc).toBeDefined();
+      expect(() => pack({} as StructPlainObject, desc!)).toThrow(/missing required field/);
+      expect(() => pack({ x: 1 } as StructPlainObject, desc!)).toThrow(/missing required field/);
+    });
+  });
+});

--- a/packages/client/src/lib/struct/struct-codec.ts
+++ b/packages/client/src/lib/struct/struct-codec.ts
@@ -291,6 +291,6 @@ function writeBitfield(
   const mask = (0xffffffff >>> (32 - bitWidth)) >>> 0;
   const v = ((value as number) & mask) >>> 0;
   const raw = readStorageUnit(view, offset, byteSize);
-  const updated = (raw & ~(mask << bitShift)) | (v << bitShift);
+  const updated = ((raw & ~(mask << bitShift)) | (v << bitShift)) >>> 0;
   writeStorageUnit(view, offset, byteSize, updated);
 }

--- a/packages/client/src/lib/struct/struct-codec.ts
+++ b/packages/client/src/lib/struct/struct-codec.ts
@@ -1,0 +1,255 @@
+import type { StructDescriptor, StructFieldDescriptor } from './struct-descriptor';
+import { getPrimitiveSize } from './struct-descriptor';
+
+/** Plain object representation of a struct (for pack input / unpack output). */
+export type StructPlainObject = Record<string, unknown>;
+
+/**
+ * Unpacks a little-endian binary buffer into a plain object using the struct descriptor.
+ * @throws Error if buffer is too small for the descriptor size.
+ */
+export function unpack(buffer: Uint8Array, descriptor: StructDescriptor): StructPlainObject {
+  if (buffer.length < descriptor.size) {
+    throw new Error(
+      `Struct unpack: buffer too small (${buffer.length} bytes, need ${descriptor.size} for ${descriptor.typeName})`
+    );
+  }
+  const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+  const out: StructPlainObject = {};
+  for (const field of descriptor.fields) {
+    out[field.name] = unpackField(view, field);
+  }
+  return out;
+}
+
+/**
+ * Packs a plain object into a little-endian Uint8Array using the struct descriptor.
+ * @throws Error if value is missing required fields or has invalid types.
+ */
+export function pack(value: StructPlainObject, descriptor: StructDescriptor): Uint8Array {
+  const buffer = new Uint8Array(descriptor.size);
+  const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+  for (const field of descriptor.fields) {
+    const v = value[field.name];
+    if (v === undefined) {
+      throw new Error(`Struct pack: missing required field "${field.name}" for ${descriptor.typeName}`);
+    }
+    packField(view, field, v);
+  }
+  return buffer;
+}
+
+function unpackField(view: DataView, field: StructFieldDescriptor): unknown {
+  const offset = field.offset;
+  if (field.nestedDescriptor) {
+    if (field.arraySize === 1) {
+      return unpack(new Uint8Array(view.buffer, view.byteOffset + offset, field.size), field.nestedDescriptor);
+    }
+    const arr: StructPlainObject[] = [];
+    const elemSize = field.nestedDescriptor.size;
+    for (let i = 0; i < field.arraySize; i++) {
+      arr.push(
+        unpack(
+          new Uint8Array(view.buffer, view.byteOffset + offset + i * elemSize, elemSize),
+          field.nestedDescriptor
+        ) as StructPlainObject
+      );
+    }
+    return arr;
+  }
+  const prim = field.primitive;
+  if (!prim) throw new Error(`Struct field "${field.name}" has neither nestedDescriptor nor primitive`);
+  if (field.arraySize > 1) {
+    const elemSize = getPrimitiveSize(prim);
+    const arr: unknown[] = [];
+    for (let i = 0; i < field.arraySize; i++) {
+      arr.push(readPrimitive(view, offset + i * elemSize, prim));
+    }
+    return arr;
+  }
+  if (field.bitWidth > 0 && field.bitWidth < field.size * 8) {
+    return readBitfield(view, offset, field.size, field.bitWidth, field.bitShift);
+  }
+  return readPrimitive(view, offset, prim);
+}
+
+function packField(view: DataView, field: StructFieldDescriptor, value: unknown): void {
+  const offset = field.offset;
+  if (field.nestedDescriptor) {
+    if (field.arraySize === 1) {
+      const buf = pack(value as StructPlainObject, field.nestedDescriptor);
+      new Uint8Array(view.buffer, view.byteOffset + offset, field.size).set(buf);
+      return;
+    }
+    const arr = value as StructPlainObject[];
+    if (!Array.isArray(arr) || arr.length !== field.arraySize) {
+      throw new Error(`Struct pack: field "${field.name}" expects array of size ${field.arraySize}`);
+    }
+    const elemSize = field.nestedDescriptor.size;
+    for (let i = 0; i < field.arraySize; i++) {
+      const slice = new Uint8Array(view.buffer, view.byteOffset + offset + i * elemSize, elemSize);
+      slice.set(pack(arr[i] as StructPlainObject, field.nestedDescriptor));
+    }
+    return;
+  }
+  const prim = field.primitive;
+  if (!prim) throw new Error(`Struct field "${field.name}" has neither nestedDescriptor nor primitive`);
+  if (field.arraySize > 1) {
+    const arr = value as unknown[];
+    if (!Array.isArray(arr) || arr.length !== field.arraySize) {
+      throw new Error(`Struct pack: field "${field.name}" expects array of size ${field.arraySize}`);
+    }
+    const elemSize = getPrimitiveSize(prim);
+    for (let i = 0; i < field.arraySize; i++) {
+      writePrimitive(view, offset + i * elemSize, prim, arr[i]);
+    }
+    return;
+  }
+  if (field.bitWidth > 0 && field.bitWidth < field.size * 8) {
+    writeBitfield(view, offset, field.size, field.bitWidth, field.bitShift, value);
+    return;
+  }
+  writePrimitive(view, offset, prim, value);
+}
+
+function readPrimitive(view: DataView, offset: number, prim: string): unknown {
+  switch (prim) {
+    case 'bool':
+      return view.getUint8(offset) !== 0;
+    case 'char':
+      return view.getInt8(offset);
+    case 'int8':
+      return view.getInt8(offset);
+    case 'uint8':
+      return view.getUint8(offset);
+    case 'int16':
+      return view.getInt16(offset, true);
+    case 'uint16':
+      return view.getUint16(offset, true);
+    case 'int32':
+      return view.getInt32(offset, true);
+    case 'uint32':
+      return view.getUint32(offset, true);
+    case 'int64':
+      // Converted to Number (loses precision beyond ±2^53). BigInt is avoided because it
+      // can't mix with Number in arithmetic and breaks JSON.stringify / Zod / React state.
+      // No built-in WPILib struct types use int64; revisit if full precision is needed.
+      return Number(view.getBigInt64(offset, true));
+    case 'uint64':
+      return Number(view.getBigUint64(offset, true));
+    case 'float':
+    case 'float32':
+      return view.getFloat32(offset, true);
+    case 'double':
+    case 'float64':
+      return view.getFloat64(offset, true);
+    default:
+      throw new Error(`Unknown primitive: ${prim}`);
+  }
+}
+
+function writePrimitive(view: DataView, offset: number, prim: string, value: unknown): void {
+  switch (prim) {
+    case 'bool':
+      view.setUint8(offset, (value as boolean) ? 1 : 0);
+      break;
+    case 'char':
+    case 'int8':
+      view.setInt8(offset, value as number);
+      break;
+    case 'uint8':
+      view.setUint8(offset, value as number);
+      break;
+    case 'int16':
+      view.setInt16(offset, value as number, true);
+      break;
+    case 'uint16':
+      view.setUint16(offset, value as number, true);
+      break;
+    case 'int32':
+      view.setInt32(offset, value as number, true);
+      break;
+    case 'uint32':
+      view.setUint32(offset, value as number, true);
+      break;
+    case 'int64':
+      view.setBigInt64(offset, BigInt(value as number), true);
+      break;
+    case 'uint64':
+      view.setBigUint64(offset, BigInt(value as number), true);
+      break;
+    case 'float':
+    case 'float32':
+      view.setFloat32(offset, value as number, true);
+      break;
+    case 'double':
+    case 'float64':
+      view.setFloat64(offset, value as number, true);
+      break;
+    default:
+      throw new Error(`Unknown primitive: ${prim}`);
+  }
+}
+
+function readStorageUnit(view: DataView, offset: number, byteSize: number): number {
+  switch (byteSize) {
+    case 1:
+      return view.getUint8(offset);
+    case 2:
+      return view.getUint16(offset, true);
+    case 4:
+      return view.getUint32(offset, true);
+    default:
+      return Number(view.getBigUint64(offset, true));
+  }
+}
+
+function writeStorageUnit(view: DataView, offset: number, byteSize: number, value: number): void {
+  switch (byteSize) {
+    case 1:
+      view.setUint8(offset, value);
+      break;
+    case 2:
+      view.setUint16(offset, value, true);
+      break;
+    case 4:
+      view.setUint32(offset, value, true);
+      break;
+    default:
+      view.setBigUint64(offset, BigInt(value), true);
+  }
+}
+
+/**
+ * Reads a bitfield value from a storage unit. Mirrors WPILib's unsigned read path:
+ * `(rawVal >>> bitShift) & bitMask`. Signed sign-extension is not implemented since
+ * WPILib only allows unsigned/bool bitfields in practice.
+ *
+ * @see DynamicStruct.java — getFieldImpl()
+ */
+function readBitfield(view: DataView, offset: number, byteSize: number, bitWidth: number, bitShift: number): number {
+  const raw = readStorageUnit(view, offset, byteSize);
+  const mask = (1 << bitWidth) - 1;
+  return (raw >>> bitShift) & mask;
+}
+
+/**
+ * Writes a bitfield value into a storage unit via read-modify-write. Clears the target
+ * bits with `~(mask << shift)`, then sets with `(value & mask) << shift`.
+ *
+ * @see DynamicStruct.java — setFieldImpl()
+ */
+function writeBitfield(
+  view: DataView,
+  offset: number,
+  byteSize: number,
+  bitWidth: number,
+  bitShift: number,
+  value: unknown
+): void {
+  const mask = (1 << bitWidth) - 1;
+  const v = ((value as number) & mask) >>> 0;
+  const raw = readStorageUnit(view, offset, byteSize);
+  const updated = (raw & ~(mask << bitShift)) | (v << bitShift);
+  writeStorageUnit(view, offset, byteSize, updated);
+}

--- a/packages/client/src/lib/struct/struct-codec.ts
+++ b/packages/client/src/lib/struct/struct-codec.ts
@@ -68,7 +68,8 @@ function unpackField(view: DataView, field: StructFieldDescriptor): unknown {
     return arr;
   }
   if (field.bitWidth > 0 && field.bitWidth < field.size * 8) {
-    return readBitfield(view, offset, field.size, field.bitWidth, field.bitShift);
+    const bitfieldValue = readBitfield(view, offset, field.size, field.bitWidth, field.bitShift);
+    return prim === 'bool' ? bitfieldValue !== 0 : bitfieldValue;
   }
   return readPrimitive(view, offset, prim);
 }
@@ -172,12 +173,36 @@ function writePrimitive(view: DataView, offset: number, prim: string, value: unk
     case 'uint32':
       view.setUint32(offset, value as number, true);
       break;
-    case 'int64':
-      view.setBigInt64(offset, BigInt(value as number), true);
+    case 'int64': {
+      const v =
+        typeof value === 'bigint'
+          ? value
+          : typeof value === 'number' && Number.isSafeInteger(value)
+            ? BigInt(value)
+            : (() => {
+                throw new Error(
+                  `Struct pack int64: value ${String(value)} is not a safe integer. ` +
+                    `Pass a BigInt for values outside ±2^53.`
+                );
+              })();
+      view.setBigInt64(offset, v, true);
       break;
-    case 'uint64':
-      view.setBigUint64(offset, BigInt(value as number), true);
+    }
+    case 'uint64': {
+      const v =
+        typeof value === 'bigint'
+          ? value
+          : typeof value === 'number' && Number.isSafeInteger(value)
+            ? BigInt(value)
+            : (() => {
+                throw new Error(
+                  `Struct pack uint64: value ${String(value)} is not a safe integer. ` +
+                    `Pass a BigInt for values outside ±2^53.`
+                );
+              })();
+      view.setBigUint64(offset, v, true);
       break;
+    }
     case 'float':
     case 'float32':
       view.setFloat32(offset, value as number, true);

--- a/packages/client/src/lib/struct/struct-codec.ts
+++ b/packages/client/src/lib/struct/struct-codec.ts
@@ -237,7 +237,8 @@ function readBitfield(view: DataView, offset: number, byteSize: number, bitWidth
     );
   }
   const raw = readStorageUnit(view, offset, byteSize);
-  const mask = (1 << bitWidth) - 1;
+  // Use unsigned mask so bitWidth=31 works: (1 << 31) would overflow to negative in JS.
+  const mask = (0xffffffff >>> (32 - bitWidth)) >>> 0;
   return (raw >>> bitShift) & mask;
 }
 
@@ -261,7 +262,8 @@ function writeBitfield(
       `Struct codec: bitfield write unsupported for byteSize=${byteSize} bitWidth=${bitWidth} (max ${MAX_BITFIELD_WIDTH} bits)`
     );
   }
-  const mask = (1 << bitWidth) - 1;
+  // Use unsigned mask so bitWidth=31 works: (1 << 31) would overflow to negative in JS.
+  const mask = (0xffffffff >>> (32 - bitWidth)) >>> 0;
   const v = ((value as number) & mask) >>> 0;
   const raw = readStorageUnit(view, offset, byteSize);
   const updated = (raw & ~(mask << bitShift)) | (v << bitShift);

--- a/packages/client/src/lib/struct/struct-codec.ts
+++ b/packages/client/src/lib/struct/struct-codec.ts
@@ -220,14 +220,22 @@ function writeStorageUnit(view: DataView, offset: number, byteSize: number, valu
   }
 }
 
+const MAX_BITFIELD_WIDTH = 31;
+
 /**
  * Reads a bitfield value from a storage unit. Mirrors WPILib's unsigned read path:
  * `(rawVal >>> bitShift) & bitMask`. Signed sign-extension is not implemented since
  * WPILib only allows unsigned/bool bitfields in practice.
+ * JS bitwise ops are 32-bit; bitfields wider than 31 bits or 8-byte storage are unsupported.
  *
  * @see DynamicStruct.java — getFieldImpl()
  */
 function readBitfield(view: DataView, offset: number, byteSize: number, bitWidth: number, bitShift: number): number {
+  if (byteSize === 8 || bitWidth > MAX_BITFIELD_WIDTH) {
+    throw new Error(
+      `Struct codec: bitfield read unsupported for byteSize=${byteSize} bitWidth=${bitWidth} (max ${MAX_BITFIELD_WIDTH} bits)`
+    );
+  }
   const raw = readStorageUnit(view, offset, byteSize);
   const mask = (1 << bitWidth) - 1;
   return (raw >>> bitShift) & mask;
@@ -236,6 +244,7 @@ function readBitfield(view: DataView, offset: number, byteSize: number, bitWidth
 /**
  * Writes a bitfield value into a storage unit via read-modify-write. Clears the target
  * bits with `~(mask << shift)`, then sets with `(value & mask) << shift`.
+ * JS bitwise ops are 32-bit; bitfields wider than 31 bits or 8-byte storage are unsupported.
  *
  * @see DynamicStruct.java — setFieldImpl()
  */
@@ -247,6 +256,11 @@ function writeBitfield(
   bitShift: number,
   value: unknown
 ): void {
+  if (byteSize === 8 || bitWidth > MAX_BITFIELD_WIDTH) {
+    throw new Error(
+      `Struct codec: bitfield write unsupported for byteSize=${byteSize} bitWidth=${bitWidth} (max ${MAX_BITFIELD_WIDTH} bits)`
+    );
+  }
   const mask = (1 << bitWidth) - 1;
   const v = ((value as number) & mask) >>> 0;
   const raw = readStorageUnit(view, offset, byteSize);

--- a/packages/client/src/lib/struct/struct-descriptor.ts
+++ b/packages/client/src/lib/struct/struct-descriptor.ts
@@ -1,0 +1,72 @@
+/**
+ * Primitive type names and their byte sizes (WPILib struct schema).
+ */
+export const PRIMITIVE_SIZES = {
+  bool: 1,
+  char: 1,
+  int8: 1,
+  uint8: 1,
+  int16: 2,
+  uint16: 2,
+  int32: 4,
+  uint32: 4,
+  int64: 8,
+  uint64: 8,
+  float: 4,
+  float32: 4,
+  double: 8,
+  float64: 8,
+} as const satisfies Record<string, number>;
+
+export type PrimitiveTypeName = keyof typeof PRIMITIVE_SIZES;
+
+/**
+ * Descriptor for a single field in a struct (with resolved offset/size for layout).
+ */
+export interface StructFieldDescriptor {
+  name: string;
+  /** Byte offset of this field within the struct. */
+  offset: number;
+  /** Storage size in bytes for one element. */
+  size: number;
+  /** 1 for non-array, >1 for fixed-size array. */
+  arraySize: number;
+  /** 0 for non-bitfield, 1–N for bitfield width in bits. */
+  bitWidth: number;
+  /** Bit offset within the storage unit (for coalesced bitfields). */
+  bitShift: number;
+  /** For enum fields: enum name → integer value. */
+  enumValues?: Record<string, number>;
+  /** Set for primitive fields. */
+  primitive?: PrimitiveTypeName;
+  /** Set for nested struct fields (resolved descriptor). */
+  nestedDescriptor?: StructDescriptor;
+}
+
+/**
+ * Descriptor for a struct type: type name, total size, and ordered fields.
+ */
+export interface StructDescriptor {
+  typeName: string;
+  /** Total size in bytes. */
+  size: number;
+  fields: StructFieldDescriptor[];
+}
+
+/**
+ * Returns the size in bytes of a primitive type.
+ */
+export function getPrimitiveSize(primitive: PrimitiveTypeName): number {
+  const size = PRIMITIVE_SIZES[primitive];
+  if (size === undefined) {
+    throw new Error(`Unknown primitive type: ${primitive}`);
+  }
+  return size;
+}
+
+/**
+ * Returns whether the given string is a known primitive type name.
+ */
+export function isPrimitiveType(typeName: string): typeName is PrimitiveTypeName {
+  return typeName in PRIMITIVE_SIZES;
+}

--- a/packages/client/src/lib/struct/struct-parser.spec.ts
+++ b/packages/client/src/lib/struct/struct-parser.spec.ts
@@ -1,0 +1,90 @@
+import { parseSchema, buildStructDescriptor } from './struct-parser';
+import type { StructDescriptor } from './struct-descriptor';
+
+describe('struct-parser', () => {
+  describe('parseSchema', () => {
+    it('parses simple schema double x;double y', () => {
+      const fields = parseSchema('double x;double y');
+      expect(fields).toHaveLength(2);
+      expect(fields[0]).toEqual({ typeName: 'double', name: 'x', arraySize: 1, bitWidth: 0 });
+      expect(fields[1]).toEqual({ typeName: 'double', name: 'y', arraySize: 1, bitWidth: 0 });
+    });
+
+    it('parses schema with nested struct Translation2d t;Rotation2d r', () => {
+      const fields = parseSchema('Translation2d t;Rotation2d r');
+      expect(fields).toHaveLength(2);
+      expect(fields[0]).toEqual({ typeName: 'Translation2d', name: 't', arraySize: 1, bitWidth: 0 });
+      expect(fields[1]).toEqual({ typeName: 'Rotation2d', name: 'r', arraySize: 1, bitWidth: 0 });
+    });
+
+    it('parses schema with array int32 arr[4]', () => {
+      const fields = parseSchema('int32 arr[4]');
+      expect(fields).toHaveLength(1);
+      expect(fields[0]).toEqual({ typeName: 'int32', name: 'arr', arraySize: 4, bitWidth: 0 });
+    });
+
+    it('parses schema with bitfield uint8 flags:4', () => {
+      const fields = parseSchema('uint8 flags:4');
+      expect(fields).toHaveLength(1);
+      expect(fields[0]).toEqual({ typeName: 'uint8', name: 'flags', arraySize: 1, bitWidth: 4 });
+    });
+
+    it('parses schema with enum enum { A=0,B=1 } int32 x', () => {
+      const fields = parseSchema('enum { A=0,B=1 } int32 x');
+      expect(fields).toHaveLength(1);
+      expect(fields[0].typeName).toBe('int32');
+      expect(fields[0].name).toBe('x');
+      expect(fields[0].enumValues).toEqual({ A: 0, B: 1 });
+    });
+
+    it('rejects invalid schema malformed tokens', () => {
+      expect(() => parseSchema('double x [')).toThrow();
+      expect(() => parseSchema('double')).toThrow();
+      expect(() => parseSchema('double x ; ; double')).toThrow();
+    });
+
+    it('handles whitespace and optional semicolons', () => {
+      const fields = parseSchema('  double   x  ;  double   y  ');
+      expect(fields).toHaveLength(2);
+      expect(fields[0].name).toBe('x');
+      expect(fields[1].name).toBe('y');
+
+      const noSemicolon = parseSchema('double x double y');
+      expect(noSemicolon).toHaveLength(2);
+    });
+  });
+
+  describe('buildStructDescriptor', () => {
+    it('builds descriptor for primitive-only schema', () => {
+      const fields = parseSchema('double x;double y');
+      const getNested = () => null;
+      const desc = buildStructDescriptor('Translation2d', fields, getNested);
+      expect(desc.typeName).toBe('Translation2d');
+      expect(desc.size).toBe(16);
+      expect(desc.fields[0]).toMatchObject({ name: 'x', offset: 0, size: 8, primitive: 'double' });
+      expect(desc.fields[1]).toMatchObject({ name: 'y', offset: 8, size: 8, primitive: 'double' });
+    });
+
+    it('rejects circular struct reference', () => {
+      const fieldsA = parseSchema('B a');
+      const fieldsB = parseSchema('A b');
+      const cache = new Map<string, StructDescriptor>();
+      function getNested(name: string): StructDescriptor | null {
+        if (name === 'B') {
+          if (!cache.has('B')) {
+            cache.set('B', buildStructDescriptor('B', fieldsB, getNested));
+          }
+          return cache.get('B') ?? null;
+        }
+        return cache.get(name) ?? null;
+      }
+      expect(() => buildStructDescriptor('A', fieldsA, getNested)).toThrow(/circular|unknown/);
+    });
+
+    it('rejects bitfield width exceeding type size', () => {
+      const fields = parseSchema('uint8 flags:16');
+      const getNested = () => null;
+      expect(() => buildStructDescriptor('Bad', fields, getNested)).toThrow(/bitfield width/);
+    });
+  });
+});

--- a/packages/client/src/lib/struct/struct-parser.ts
+++ b/packages/client/src/lib/struct/struct-parser.ts
@@ -151,8 +151,9 @@ export function parseSchema(schema: string): ParsedField[] {
 function parseEnumEntries(lex: Lexer): Record<string, number> {
   const enumValues: Record<string, number> = {};
   for (;;) {
+    if (lex.peek() === '}') break;
     const id = lex.next();
-    if (!id || id === '}') break;
+    if (!id) break;
     if (PUNCT.test(id) || INT.test(id)) throw new Error('Struct schema: expected identifier in enum entry');
     const eq = lex.next();
     if (eq !== '=') throw new Error('Struct schema: expected "=" in enum entry');

--- a/packages/client/src/lib/struct/struct-parser.ts
+++ b/packages/client/src/lib/struct/struct-parser.ts
@@ -188,8 +188,6 @@ export function buildStructDescriptor(
   parsedFields: ParsedField[],
   getNestedDescriptor: (name: string) => StructDescriptor | null
 ): StructDescriptor {
-  const seen = new Set<string>([typeName]);
-
   function resolveElemSize(f: ParsedField): { elemSize: number; nested: StructDescriptor | null } {
     if (isPrimitiveType(f.typeName)) {
       const elemSize = getPrimitiveSize(f.typeName as PrimitiveTypeName);
@@ -200,12 +198,12 @@ export function buildStructDescriptor(
       }
       return { elemSize, nested: null };
     }
+    if (f.typeName === typeName) {
+      throw new Error(`Struct schema: circular struct reference "${f.typeName}" in "${typeName}"`);
+    }
     const nested = getNestedDescriptor(f.typeName);
     if (!nested) {
       throw new Error(`Struct schema: unknown or circular struct type "${f.typeName}" in "${typeName}"`);
-    }
-    if (seen.has(f.typeName)) {
-      throw new Error(`Struct schema: circular struct reference "${f.typeName}" in "${typeName}"`);
     }
     return { elemSize: nested.size, nested };
   }

--- a/packages/client/src/lib/struct/struct-parser.ts
+++ b/packages/client/src/lib/struct/struct-parser.ts
@@ -1,0 +1,288 @@
+import {
+  isPrimitiveType,
+  getPrimitiveSize,
+  type PrimitiveTypeName,
+  type StructDescriptor,
+  type StructFieldDescriptor,
+} from './struct-descriptor';
+
+/** Single punctuation or keyword token. */
+const PUNCT = /^[[\]{}:;,=]/;
+/** Identifier: letter or _ then alphanumeric or _. */
+const IDENT = /^[a-zA-Z_][a-zA-Z0-9_]*/;
+/** Integer: optional minus then digits. */
+const INT = /^-?\d+/;
+/** Whitespace. */
+const WS = /^[\s\r\n\t]+/;
+
+export type ParsedField = {
+  typeName: string;
+  name: string;
+  arraySize: number;
+  bitWidth: number;
+  enumValues?: Record<string, number>;
+};
+
+class Lexer {
+  private input: string;
+  private pos = 0;
+
+  constructor(input: string) {
+    this.input = input;
+  }
+
+  eof(): boolean {
+    this.skipWhitespace();
+    return this.pos >= this.input.length;
+  }
+
+  private skipWhitespace(): void {
+    while (this.pos < this.input.length) {
+      const m = this.input.slice(this.pos).match(WS);
+      if (m) {
+        this.pos += m[0].length;
+      } else {
+        break;
+      }
+    }
+  }
+
+  /** Returns next token as string, or null if eof. */
+  next(): string | null {
+    this.skipWhitespace();
+    if (this.pos >= this.input.length) return null;
+    const rest = this.input.slice(this.pos);
+    const p = rest.match(PUNCT);
+    if (p) {
+      this.pos += p[0].length;
+      return p[0];
+    }
+    const i = rest.match(INT);
+    if (i) {
+      this.pos += i[0].length;
+      return i[0];
+    }
+    const id = rest.match(IDENT);
+    if (id) {
+      this.pos += id[0].length;
+      return id[0];
+    }
+    throw new Error(`Struct schema lexer: unexpected character at position ${this.pos}`);
+  }
+
+  /** Peek next token without consuming. */
+  peek(): string | null {
+    const saved = this.pos;
+    const t = this.next();
+    this.pos = saved;
+    return t;
+  }
+}
+
+/**
+ * Parses a WPILib struct schema string into a list of field declarations.
+ * @param schema - Schema string (e.g. "double x;double y" or "Translation2d translation;Rotation2d rotation").
+ * @returns Array of parsed fields.
+ * @throws Error on malformed schema.
+ */
+export function parseSchema(schema: string): ParsedField[] {
+  const lex = new Lexer(schema);
+  const fields: ParsedField[] = [];
+
+  while (!lex.eof()) {
+    let enumValues: Record<string, number> | undefined;
+
+    const first = lex.next();
+    if (!first) break;
+
+    if (first === 'enum') {
+      const open = lex.next();
+      if (open !== '{') throw new Error('Struct schema: expected "{" after enum');
+      enumValues = parseEnumEntries(lex);
+      const close = lex.next();
+      if (close !== '}') throw new Error('Struct schema: expected "}" after enum entries');
+    } else if (first === '{') {
+      enumValues = parseEnumEntries(lex);
+      const close = lex.next();
+      if (close !== '}') throw new Error('Struct schema: expected "}" after enum entries');
+    }
+
+    const typeName = first === 'enum' || first === '{' ? lex.next() : first;
+    if (!typeName || PUNCT.test(typeName) || INT.test(typeName)) {
+      throw new Error('Struct schema: expected type after declaration start');
+    }
+
+    const name = lex.next();
+    if (!name || PUNCT.test(name) || INT.test(name)) {
+      throw new Error('Struct schema: expected identifier after type');
+    }
+
+    let arraySize = 1;
+    let bitWidth = 0;
+
+    const afterName = lex.peek();
+    if (afterName === '[') {
+      lex.next();
+      const sizeTok = lex.next();
+      if (!sizeTok || !INT.test(sizeTok)) throw new Error('Struct schema: expected integer in array size');
+      const n = parseInt(sizeTok, 10);
+      if (n <= 0) throw new Error('Struct schema: array size must be positive');
+      arraySize = n;
+      const close = lex.next();
+      if (close !== ']') throw new Error('Struct schema: expected "]" after array size');
+    } else if (afterName === ':') {
+      lex.next();
+      const widthTok = lex.next();
+      if (!widthTok || !INT.test(widthTok)) throw new Error('Struct schema: expected integer in bitfield width');
+      bitWidth = parseInt(widthTok, 10);
+      if (bitWidth <= 0) throw new Error('Struct schema: bitfield width must be positive');
+    }
+
+    fields.push({ typeName, name, arraySize, bitWidth, enumValues });
+
+    while (lex.peek() === ';') {
+      lex.next();
+    }
+  }
+
+  return fields;
+}
+
+function parseEnumEntries(lex: Lexer): Record<string, number> {
+  const enumValues: Record<string, number> = {};
+  for (;;) {
+    const id = lex.next();
+    if (!id || id === '}') break;
+    if (PUNCT.test(id) || INT.test(id)) throw new Error('Struct schema: expected identifier in enum entry');
+    const eq = lex.next();
+    if (eq !== '=') throw new Error('Struct schema: expected "=" in enum entry');
+    const num = lex.next();
+    if (!num || !INT.test(num)) throw new Error('Struct schema: expected integer in enum value');
+    enumValues[id] = parseInt(num, 10);
+    const next = lex.peek();
+    if (next === ',') {
+      lex.next();
+    } else if (next === '}') {
+      break;
+    } else if (next !== null) {
+      throw new Error(`Struct schema: unexpected token "${next}" in enum`);
+    }
+  }
+  return enumValues;
+}
+
+/**
+ * Builds a StructDescriptor from parsed fields and a resolver for nested struct sizes.
+ *
+ * Implements the WPILib `StructDescriptor.calculateOffsets()` algorithm for bitfield
+ * coalescing. Fields are densely packed with no alignment padding. Consecutive bitfields
+ * of the same underlying type share a single storage unit (e.g. two `uint8:4` fields
+ * occupy 1 byte, not 2). When the type changes or bits overflow the storage unit, a new
+ * unit starts.
+ *
+ * @see https://github.com/wpilibsuite/allwpilib — StructDescriptor.java, calculateOffsets()
+ */
+export function buildStructDescriptor(
+  typeName: string,
+  parsedFields: ParsedField[],
+  getNestedDescriptor: (name: string) => StructDescriptor | null
+): StructDescriptor {
+  const seen = new Set<string>([typeName]);
+
+  function resolveElemSize(f: ParsedField): { elemSize: number; nested: StructDescriptor | null } {
+    if (isPrimitiveType(f.typeName)) {
+      const elemSize = getPrimitiveSize(f.typeName as PrimitiveTypeName);
+      if (f.bitWidth > 0 && f.bitWidth > elemSize * 8) {
+        throw new Error(
+          `Struct schema: bitfield width ${f.bitWidth} exceeds type ${f.typeName} size (${elemSize} bytes)`
+        );
+      }
+      return { elemSize, nested: null };
+    }
+    const nested = getNestedDescriptor(f.typeName);
+    if (!nested) {
+      throw new Error(`Struct schema: unknown or circular struct type "${f.typeName}" in "${typeName}"`);
+    }
+    if (seen.has(f.typeName)) {
+      throw new Error(`Struct schema: circular struct reference "${f.typeName}" in "${typeName}"`);
+    }
+    return { elemSize: nested.size, nested };
+  }
+
+  const fields: StructFieldDescriptor[] = [];
+  // Mirrors WPILib's calculateOffsets state: byte offset, bit position within the
+  // current bitfield storage unit, and the byte-size of that storage unit (0 = none active).
+  let offset = 0;
+  let shift = 0;
+  let prevBitfieldSize = 0;
+
+  for (const f of parsedFields) {
+    const { elemSize, nested } = resolveElemSize(f);
+    const isBitfield = f.bitWidth > 0 && f.bitWidth < elemSize * 8;
+
+    if (!isBitfield) {
+      // Non-bitfield: close any active bitfield storage unit, then lay out normally.
+      shift = 0;
+      offset += prevBitfieldSize;
+      prevBitfieldSize = 0;
+
+      if (nested) {
+        fields.push({
+          name: f.name,
+          offset,
+          size: elemSize,
+          arraySize: f.arraySize,
+          bitWidth: 0,
+          bitShift: 0,
+          nestedDescriptor: nested,
+        });
+      } else {
+        fields.push({
+          name: f.name,
+          offset,
+          size: elemSize,
+          arraySize: f.arraySize,
+          bitWidth: 0,
+          bitShift: 0,
+          enumValues: f.enumValues,
+          primitive: f.typeName as PrimitiveTypeName,
+        });
+      }
+      offset += elemSize * f.arraySize;
+    } else {
+      // Bitfield coalescing: consecutive bitfields of the same underlying type pack into
+      // a shared storage unit at increasing bitShift offsets (LSB-first). Three cases:
+      const bitWidth = f.bitWidth;
+      const isBool = f.typeName === 'bool';
+
+      if (isBool && prevBitfieldSize !== 0 && shift + 1 <= prevBitfieldSize * 8) {
+        // Case 1: Bool adopts the preceding bitfield's storage type if it fits (1 bit).
+        // This is a WPILib special case — a bool:1 packs into any active storage unit.
+      } else if (elemSize !== prevBitfieldSize || shift + bitWidth > elemSize * 8) {
+        // Case 2: Type changed or bits won't fit — start a new storage unit.
+        shift = 0;
+        offset += prevBitfieldSize;
+      }
+      // Case 3 (implicit): Same type, fits — continues packing into current unit.
+
+      prevBitfieldSize =
+        isBool && prevBitfieldSize !== 0 && shift + 1 <= prevBitfieldSize * 8 ? prevBitfieldSize : elemSize;
+
+      fields.push({
+        name: f.name,
+        offset,
+        size: prevBitfieldSize,
+        arraySize: 1,
+        bitWidth,
+        bitShift: shift,
+        enumValues: f.enumValues,
+        primitive: f.typeName as PrimitiveTypeName,
+      });
+      shift += bitWidth;
+    }
+  }
+
+  // Account for any trailing bitfield storage unit.
+  const totalSize = offset + prevBitfieldSize;
+  return { typeName, size: totalSize, fields };
+}

--- a/packages/client/src/lib/struct/struct-schema-manager.spec.ts
+++ b/packages/client/src/lib/struct/struct-schema-manager.spec.ts
@@ -1,0 +1,149 @@
+import WSMock from 'vitest-websocket-mock';
+
+import { PubSubClient } from '../pubsub/pubsub';
+import { StructSchemaManager } from './struct-schema-manager';
+
+describe('StructSchemaManager', () => {
+  let client: PubSubClient;
+  let server: WSMock;
+  const serverUrl = 'ws://localhost:5813/nt/5678';
+
+  beforeAll(async () => {
+    server = new WSMock(serverUrl);
+    client = PubSubClient.getInstance(serverUrl);
+    await server.connected;
+  });
+
+  beforeEach(() => {
+    client['topics'].clear();
+    client['prefixTopics'].clear();
+    client['knownTopicParams'].clear();
+    client['inFlightOperations'].clear();
+    client['_isCleaningUp'] = false;
+  });
+
+  describe('constructor', () => {
+    it('subscribes to /.schema/struct: prefix', () => {
+      const manager = new StructSchemaManager(client);
+      expect(manager).toBeDefined();
+      expect(client.getPrefixTopicFromName('/.schema/struct:')).toBeDefined();
+    });
+  });
+
+  describe('handleSchemaUpdate', () => {
+    it('decode UTF-8, parse, cache', () => {
+      const manager = new StructSchemaManager(client);
+      const prefixTopic = client.getPrefixTopicFromName('/.schema/struct:');
+      if (!prefixTopic) throw new Error('expected prefix topic');
+      const schemaStr = 'double x;double y';
+      prefixTopic.updateValue(
+        { name: '/.schema/struct:Translation2d', id: 1, type: 'structschema', properties: {} },
+        new TextEncoder().encode(schemaStr),
+        0
+      );
+      const desc = manager.fetchDescriptor('Translation2d');
+      expect(desc).not.toBeNull();
+      expect(desc?.typeName).toBe('Translation2d');
+      expect(desc?.size).toBe(16);
+      expect(desc?.fields).toHaveLength(2);
+    });
+
+    it('ignores null value', () => {
+      const manager = new StructSchemaManager(client);
+      const prefixTopic = client.getPrefixTopicFromName('/.schema/struct:');
+      if (!prefixTopic) throw new Error('expected prefix topic');
+      prefixTopic.updateValue(
+        { name: '/.schema/struct:SomeType', id: 1, type: 'structschema', properties: {} },
+        null as unknown as Uint8Array,
+        0
+      );
+      expect(manager.fetchDescriptor('SomeType')).toBeNull();
+    });
+  });
+
+  describe('fetchDescriptor', () => {
+    it('returns descriptor when cached', () => {
+      const manager = new StructSchemaManager(client);
+      const prefixTopic = client.getPrefixTopicFromName('/.schema/struct:');
+      if (!prefixTopic) throw new Error('expected prefix topic');
+      prefixTopic.updateValue(
+        { name: '/.schema/struct:Rotation2d', id: 2, type: 'structschema', properties: {} },
+        new TextEncoder().encode('double value'),
+        0
+      );
+      const d1 = manager.fetchDescriptor('Rotation2d');
+      const d2 = manager.fetchDescriptor('Rotation2d');
+      expect(d1).toBe(d2);
+      expect(d1?.typeName).toBe('Rotation2d');
+    });
+
+    it('returns null when not cached', () => {
+      const manager = new StructSchemaManager(client);
+      expect(manager.fetchDescriptor('NonExistentType')).toBeNull();
+    });
+
+    it('nested structs resolved in dependency order', () => {
+      const manager = new StructSchemaManager(client);
+      const prefixTopic = client.getPrefixTopicFromName('/.schema/struct:');
+      if (!prefixTopic) throw new Error('expected prefix topic');
+      prefixTopic.updateValue(
+        { name: '/.schema/struct:Translation2d', id: 1, type: 'structschema', properties: {} },
+        new TextEncoder().encode('double x;double y'),
+        0
+      );
+      prefixTopic.updateValue(
+        { name: '/.schema/struct:Rotation2d', id: 2, type: 'structschema', properties: {} },
+        new TextEncoder().encode('double value'),
+        0
+      );
+      prefixTopic.updateValue(
+        { name: '/.schema/struct:Pose2d', id: 3, type: 'structschema', properties: {} },
+        new TextEncoder().encode('Translation2d translation;Rotation2d rotation'),
+        0
+      );
+      const poseDesc = manager.fetchDescriptor('Pose2d');
+      expect(poseDesc).not.toBeNull();
+      expect(poseDesc?.size).toBe(24);
+      expect(poseDesc?.fields[0].nestedDescriptor?.typeName).toBe('Translation2d');
+      expect(poseDesc?.fields[1].nestedDescriptor?.typeName).toBe('Rotation2d');
+    });
+
+    it('returns built-in descriptor when not in network cache', () => {
+      const manager = new StructSchemaManager(client);
+      const desc = manager.fetchDescriptor('Pose2d');
+      expect(desc).not.toBeNull();
+      expect(desc?.typeName).toBe('Pose2d');
+      expect(desc?.size).toBe(24);
+    });
+  });
+
+  describe('hasSchema', () => {
+    it('returns true when descriptor available', () => {
+      const manager = new StructSchemaManager(client);
+      expect(manager.hasSchema('struct:Pose2d')).toBe(true);
+      expect(manager.hasSchema('Pose2d')).toBe(true);
+    });
+    it('returns false when not available', () => {
+      const manager = new StructSchemaManager(client);
+      manager.clearCache();
+      expect(manager.hasSchema('NonExistent')).toBe(false);
+    });
+  });
+
+  describe('clearCache', () => {
+    it('clears all cached descriptors', () => {
+      const manager = new StructSchemaManager(client);
+      const prefixTopic = client.getPrefixTopicFromName('/.schema/struct:');
+      if (!prefixTopic) throw new Error('expected prefix topic');
+      prefixTopic.updateValue(
+        { name: '/.schema/struct:Custom', id: 1, type: 'structschema', properties: {} },
+        new TextEncoder().encode('double a'),
+        0
+      );
+      expect(manager.fetchDescriptor('Custom')).not.toBeNull();
+      manager.clearCache();
+      expect(manager.fetchDescriptor('Custom')).toBeNull();
+      expect(manager.fetchDescriptor('Pose2d')).not.toBeNull(); // built-ins survive clearCache
+    });
+  });
+});

--- a/packages/client/src/lib/struct/struct-schema-manager.ts
+++ b/packages/client/src/lib/struct/struct-schema-manager.ts
@@ -1,0 +1,164 @@
+import { NetworkTablesTypeInfos } from '../types/types';
+import type { AnnounceMessageParams } from '../types/types';
+import { parseSchema, buildStructDescriptor } from './struct-parser';
+import type { ParsedField } from './struct-parser';
+import type { StructDescriptor } from './struct-descriptor';
+import { getBuiltInDescriptor, getBuiltInSchemaString } from './built-in-schemas';
+import { NetworkTablesPrefixTopic } from '../pubsub/prefix-topic';
+import { NetworkTablesTopic } from '../pubsub/topic';
+import type { PubSubClient } from '../pubsub/pubsub';
+import { pubsubLogger } from '../util/logger';
+
+const STRUCT_SCHEMA_PREFIX = '/.schema/struct:';
+
+/**
+ * Manages struct schema fetching and caching from NetworkTables.
+ * Subscribes to `/.schema/struct:*` and parses/caches descriptors by type name.
+ */
+export class StructSchemaManager {
+  private readonly parsedFieldsCache = new Map<string, ParsedField[]>();
+  private readonly descriptorCache = new Map<string, StructDescriptor>();
+  private readonly schemaStringCache = new Map<string, string>();
+  private readonly pendingTypeNames = new Set<string>();
+  private readonly schemaPrefixTopic: NetworkTablesPrefixTopic;
+  private readonly client: PubSubClient;
+
+  constructor(client: PubSubClient) {
+    this.client = client;
+    this.schemaPrefixTopic = new NetworkTablesPrefixTopic(client, STRUCT_SCHEMA_PREFIX);
+    this.schemaPrefixTopic.subscribe(
+      (value, params) => {
+        this.handleSchemaUpdate(value as Uint8Array | null, params);
+      },
+      {},
+      undefined,
+      true
+    );
+  }
+
+  /**
+   * Handles schema updates from the prefix topic subscription.
+   * Decodes UTF-8 bytes to string, parses schema, and caches descriptor when dependencies are ready.
+   */
+  private handleSchemaUpdate(value: Uint8Array | null, params: AnnounceMessageParams): void {
+    if (value == null) return;
+    if (!ArrayBuffer.isView(value)) return;
+
+    const typeName = params.name.substring(STRUCT_SCHEMA_PREFIX.length);
+    if (!typeName) return;
+
+    const schemaString = new TextDecoder().decode(value);
+    this.schemaStringCache.set(typeName, schemaString);
+    let parsed: ParsedField[];
+    try {
+      parsed = parseSchema(schemaString);
+    } catch (err) {
+      pubsubLogger.debug('Failed to parse struct schema', { typeName, error: err });
+      return;
+    }
+    this.parsedFieldsCache.set(typeName, parsed);
+    this.pendingTypeNames.add(typeName);
+    this.tryBuildPending();
+  }
+
+  private getNested(name: string): StructDescriptor | null {
+    return this.descriptorCache.get(name) ?? getBuiltInDescriptor(name) ?? null;
+  }
+
+  private tryBuildPending(): void {
+    while (this.pendingTypeNames.size > 0) {
+      let builtAny = false;
+      for (const typeName of this.pendingTypeNames) {
+        const fields = this.parsedFieldsCache.get(typeName);
+        if (!fields || this.descriptorCache.has(typeName)) continue;
+        try {
+          const descriptor = buildStructDescriptor(typeName, fields, (n) => this.getNested(n));
+          this.descriptorCache.set(typeName, descriptor);
+          this.descriptorCache.set(`struct:${typeName}`, descriptor);
+          this.pendingTypeNames.delete(typeName);
+          builtAny = true;
+        } catch (err) {
+          pubsubLogger.debug('Deferred struct descriptor build', { typeName, error: err });
+        }
+      }
+      if (!builtAny) break;
+    }
+  }
+
+  /**
+   * Returns the struct descriptor for the given type name or type string (e.g. "Pose2d" or "struct:Pose2d").
+   * Returns null if not in cache and not a built-in (built-ins are resolved on first use).
+   */
+  fetchDescriptor(typeNameOrTypeString: string): StructDescriptor | null {
+    const typeName = typeNameOrTypeString.startsWith('struct:') ? typeNameOrTypeString.slice(7) : typeNameOrTypeString;
+    const cached = this.descriptorCache.get(typeName) ?? this.descriptorCache.get(`struct:${typeName}`);
+    if (cached) return cached;
+    const builtIn = getBuiltInDescriptor(typeName);
+    if (builtIn) return builtIn;
+    return null;
+  }
+
+  hasSchema(typeString: string): boolean {
+    return this.fetchDescriptor(typeString) != null;
+  }
+
+  clearCache(): void {
+    this.parsedFieldsCache.clear();
+    this.descriptorCache.clear();
+    this.schemaStringCache.clear();
+    this.pendingTypeNames.clear();
+  }
+
+  /**
+   * Publishes nested struct schemas to NetworkTables (nested first), then the given descriptor's schema.
+   * Used when publishing a struct topic so subscribers can decode.
+   */
+  async addSchema(descriptor: StructDescriptor): Promise<void> {
+    const typeName = descriptor.typeName;
+    const schemaTopicName = `${STRUCT_SCHEMA_PREFIX}${typeName}`;
+    const operationKey = `schema:${schemaTopicName}`;
+    await this.client.getOrCreateInFlightOperation(operationKey, async () => {
+      const nested = this.collectNestedTypeNames(descriptor);
+      for (const name of nested) {
+        await this.publishSchemaTopic(name);
+      }
+      await this.publishSchemaTopic(typeName);
+    });
+  }
+
+  private collectNestedTypeNames(desc: StructDescriptor): string[] {
+    const seen = new Set<string>();
+    const out: string[] = [];
+    const visit = (d: StructDescriptor) => {
+      for (const f of d.fields) {
+        if (f.nestedDescriptor && !seen.has(f.nestedDescriptor.typeName)) {
+          seen.add(f.nestedDescriptor.typeName);
+          visit(f.nestedDescriptor);
+          out.push(f.nestedDescriptor.typeName);
+        }
+      }
+    };
+    visit(desc);
+    return out;
+  }
+
+  private async publishSchemaTopic(typeName: string): Promise<void> {
+    const schemaTopicName = `${STRUCT_SCHEMA_PREFIX}${typeName}`;
+    const schemaString = this.schemaStringCache.get(typeName) ?? getBuiltInSchemaString(typeName);
+    if (!schemaString) return;
+    let topic = this.client.getTopicFromName(schemaTopicName) as NetworkTablesTopic<Uint8Array> | null;
+    if (!topic) {
+      topic = new NetworkTablesTopic(this.client, schemaTopicName, NetworkTablesTypeInfos.kUint8Array);
+    }
+    const pubuid = this.client.messenger.getNextPubUID();
+    topic['_pubuid'] = pubuid;
+    topic['_publisher'] = true;
+    await this.client.messenger.publish({
+      name: schemaTopicName,
+      pubuid,
+      type: 'structschema',
+      properties: { retained: true },
+    });
+    this.client.updateServer(topic, new TextEncoder().encode(schemaString));
+  }
+}

--- a/packages/client/src/lib/struct/struct-schema-manager.ts
+++ b/packages/client/src/lib/struct/struct-schema-manager.ts
@@ -162,7 +162,7 @@ export class StructSchemaManager {
 
     let topic = this.client.getTopicFromName<Uint8Array>(schemaTopicName);
     if (!topic) {
-      topic = new NetworkTablesTopic(this.client, schemaTopicName, NetworkTablesTypeInfos.kStructSchema);
+      topic = new NetworkTablesTopic<Uint8Array>(this.client, schemaTopicName, NetworkTablesTypeInfos.kStructSchema);
     }
 
     if (topic.typeInfo[1] === 'structschema') {

--- a/packages/client/src/lib/struct/struct-schema-manager.ts
+++ b/packages/client/src/lib/struct/struct-schema-manager.ts
@@ -20,6 +20,8 @@ export class StructSchemaManager {
   private readonly descriptorCache = new Map<string, StructDescriptor>();
   private readonly schemaStringCache = new Map<string, string>();
   private readonly pendingTypeNames = new Set<string>();
+  /** Type names for which we have already published a schema topic (avoids redundant republish). */
+  private readonly publishedSchemaTypes = new Set<string>();
   private readonly schemaPrefixTopic: NetworkTablesPrefixTopic;
   private readonly client: PubSubClient;
 
@@ -111,6 +113,7 @@ export class StructSchemaManager {
     this.descriptorCache.clear();
     this.schemaStringCache.clear();
     this.pendingTypeNames.clear();
+    this.publishedSchemaTypes.clear();
   }
 
   /**
@@ -149,30 +152,35 @@ export class StructSchemaManager {
   }
 
   private async publishSchemaTopic(typeName: string): Promise<void> {
+    if (this.publishedSchemaTypes.has(typeName)) return;
+
     const schemaTopicName = `${STRUCT_SCHEMA_PREFIX}${typeName}`;
     const schemaString = this.schemaStringCache.get(typeName) ?? getBuiltInSchemaString(typeName);
     if (!schemaString) return;
 
-    // Create or get the schema topic (as raw/ArrayBuffer type for internal use)
-    let topic = this.client.getTopicFromName(schemaTopicName) as NetworkTablesTopic<Uint8Array> | null;
+    const encodedSchema = new TextEncoder().encode(schemaString);
+
+    let topic = this.client.getTopicFromName<Uint8Array>(schemaTopicName);
     if (!topic) {
-      topic = new NetworkTablesTopic(this.client, schemaTopicName, NetworkTablesTypeInfos.kUint8Array);
+      topic = new NetworkTablesTopic(this.client, schemaTopicName, NetworkTablesTypeInfos.kStructSchema);
     }
 
-    // Publish the schema topic with type "structschema" and retained property
-    // We need to use the messenger directly to publish with a custom type string
-    const pubuid = this.client.messenger.getNextPubUID();
-    // Set pubuid so topic.announce() can match when messenger invokes _onAnnounce before resolving.
-    // Messenger guarantees publish() resolves only after _onAnnounce, so _publisher is set by then.
-    topic['_pubuid'] = pubuid;
-    await this.client.messenger.publish({
-      name: schemaTopicName,
-      pubuid,
-      type: 'structschema',
-      properties: { retained: true },
-    });
+    if (topic.typeInfo[1] === 'structschema') {
+      await topic.publish({ retained: true });
+      topic.setValue(encodedSchema);
+    } else {
+      // Existing topic created with older code (e.g. type 'raw'); publish with custom type via messenger
+      const pubuid = this.client.messenger.getNextPubUID();
+      topic['_pubuid'] = pubuid;
+      await this.client.messenger.publish({
+        name: schemaTopicName,
+        pubuid,
+        type: 'structschema',
+        properties: { retained: true },
+      });
+      this.client.updateServer(topic, encodedSchema);
+    }
 
-    // Set the schema value (UTF-8 encoded schema string) as the default value
-    this.client.updateServer(topic, new TextEncoder().encode(schemaString));
+    this.publishedSchemaTypes.add(typeName);
   }
 }

--- a/packages/client/src/lib/struct/struct-schema-manager.ts
+++ b/packages/client/src/lib/struct/struct-schema-manager.ts
@@ -25,7 +25,9 @@ export class StructSchemaManager {
 
   constructor(client: PubSubClient) {
     this.client = client;
+    // Create a prefix topic for all struct schema topics
     this.schemaPrefixTopic = new NetworkTablesPrefixTopic(client, STRUCT_SCHEMA_PREFIX);
+    // Subscribe to all schema topics and automatically decode and cache them
     this.schemaPrefixTopic.subscribe(
       (value, params) => {
         this.handleSchemaUpdate(value as Uint8Array | null, params);
@@ -39,6 +41,8 @@ export class StructSchemaManager {
   /**
    * Handles schema updates from the prefix topic subscription.
    * Decodes UTF-8 bytes to string, parses schema, and caches descriptor when dependencies are ready.
+   * @param value - The value of the schema update (null when a topic is unannounced).
+   * @param params - The parameters of the announce message.
    */
   private handleSchemaUpdate(value: Uint8Array | null, params: AnnounceMessageParams): void {
     if (value == null) return;
@@ -116,6 +120,8 @@ export class StructSchemaManager {
   async addSchema(descriptor: StructDescriptor): Promise<void> {
     const typeName = descriptor.typeName;
     const schemaTopicName = `${STRUCT_SCHEMA_PREFIX}${typeName}`;
+    // Use unified in-flight protection from PubSubClient
+    // Key format: "schema:" prefix to avoid conflicts with topic publishes
     const operationKey = `schema:${schemaTopicName}`;
     await this.client.getOrCreateInFlightOperation(operationKey, async () => {
       const nested = this.collectNestedTypeNames(descriptor);
@@ -146,19 +152,27 @@ export class StructSchemaManager {
     const schemaTopicName = `${STRUCT_SCHEMA_PREFIX}${typeName}`;
     const schemaString = this.schemaStringCache.get(typeName) ?? getBuiltInSchemaString(typeName);
     if (!schemaString) return;
+
+    // Create or get the schema topic (as raw/ArrayBuffer type for internal use)
     let topic = this.client.getTopicFromName(schemaTopicName) as NetworkTablesTopic<Uint8Array> | null;
     if (!topic) {
       topic = new NetworkTablesTopic(this.client, schemaTopicName, NetworkTablesTypeInfos.kUint8Array);
     }
+
+    // Publish the schema topic with type "structschema" and retained property
+    // We need to use the messenger directly to publish with a custom type string
     const pubuid = this.client.messenger.getNextPubUID();
+    // Set pubuid so topic.announce() can match when messenger invokes _onAnnounce before resolving.
+    // Messenger guarantees publish() resolves only after _onAnnounce, so _publisher is set by then.
     topic['_pubuid'] = pubuid;
-    topic['_publisher'] = true;
     await this.client.messenger.publish({
       name: schemaTopicName,
       pubuid,
       type: 'structschema',
       properties: { retained: true },
     });
+
+    // Set the schema value (UTF-8 encoded schema string) as the default value
     this.client.updateServer(topic, new TextEncoder().encode(schemaString));
   }
 }

--- a/packages/client/src/lib/types/schemas.spec.ts
+++ b/packages/client/src/lib/types/schemas.spec.ts
@@ -27,6 +27,11 @@ describe('schema', () => {
       expect(typeStringSchema.safeParse('boolean').success).toBe(true);
       expect(typeStringSchema.safeParse('string').success).toBe(true);
     });
+
+    it('rejects non-string values (NT 4.1 JSON text frames always use string types)', () => {
+      expect(typeStringSchema.safeParse(0).success).toBe(false);
+      expect(typeStringSchema.safeParse(5).success).toBe(false);
+    });
   });
 
   describe('typeNumSchema', () => {

--- a/packages/client/src/lib/types/schemas.ts
+++ b/packages/client/src/lib/types/schemas.ts
@@ -4,28 +4,6 @@ import { z } from 'zod';
 export const finiteNumSchema = z.number().finite();
 export const integerSchema = finiteNumSchema.int();
 
-/** Schema for type strings in the NT protocol. */
-export const typeStringSchema = z.union([
-  z.literal('boolean'),
-  z.literal('double'),
-  z.literal('int'),
-  z.literal('float'),
-  z.literal('string'),
-  z.literal('json'),
-  z.literal('raw'),
-  z.literal('rpc'),
-  z.literal('msgpack'),
-  z.literal('protobuf'),
-  z.literal('boolean[]'),
-  z.literal('double[]'),
-  z.literal('int[]'),
-  z.literal('float[]'),
-  z.literal('string[]'),
-  z.string().startsWith('proto:'),
-  z.string().startsWith('struct:'),
-  z.string().startsWith('photonstruct:'),
-]);
-
 /** Schema for type numbers in the NT protocol. */
 export const typeNumSchema = z.union([
   z.literal(0),
@@ -39,6 +17,29 @@ export const typeNumSchema = z.union([
   z.literal(18),
   z.literal(19),
   z.literal(20),
+]);
+
+/** Schema for type strings in the NT protocol (JSON text frames always use strings per NT 4.1 spec). */
+export const typeStringSchema = z.union([
+  z.literal('boolean'),
+  z.literal('double'),
+  z.literal('int'),
+  z.literal('float'),
+  z.literal('string'),
+  z.literal('json'),
+  z.literal('raw'),
+  z.literal('rpc'),
+  z.literal('msgpack'),
+  z.literal('structschema'),
+  z.literal('protobuf'),
+  z.literal('boolean[]'),
+  z.literal('double[]'),
+  z.literal('int[]'),
+  z.literal('float[]'),
+  z.literal('string[]'),
+  z.string().startsWith('proto:'),
+  z.string().startsWith('struct:'),
+  z.string().startsWith('photonstruct:'),
 ]);
 
 /** Schema for topic properties in the NT protocol. */

--- a/packages/client/src/lib/types/types.spec.ts
+++ b/packages/client/src/lib/types/types.spec.ts
@@ -121,15 +121,15 @@ describe('NetworkTablesTypeInfos', () => {
 
     it('should accept Uint8Array for structschema type string', () => {
       const array = new Uint8Array([100, 111, 117, 98, 108, 101]); // "double" in UTF-8
-      expect(NetworkTablesTypeInfos.validateData([5, 'structschema'], array)).toEqual(array);
+      expect(NetworkTablesTypeInfos.validateData(NetworkTablesTypeInfos.kStructSchema, array)).toEqual(array);
     });
 
     it('should throw for non-Uint8Array when struct or structschema type expected', () => {
       expect(() => NetworkTablesTypeInfos.validateData([5, 'struct:Pose2d'], 'not bytes')).toThrow(
         /Invalid struct value: expected Uint8Array/
       );
-      expect(() => NetworkTablesTypeInfos.validateData([5, 'structschema'], 'not bytes')).toThrow(
-        /Invalid struct value: expected Uint8Array/
+      expect(() => NetworkTablesTypeInfos.validateData(NetworkTablesTypeInfos.kStructSchema, 'not bytes')).toThrow(
+        /Invalid struct schema value/
       );
     });
 

--- a/packages/client/src/lib/types/types.spec.ts
+++ b/packages/client/src/lib/types/types.spec.ts
@@ -114,6 +114,25 @@ describe('NetworkTablesTypeInfos', () => {
       );
     });
 
+    it('should accept Uint8Array for struct type string', () => {
+      const array = new Uint8Array([1, 2, 3]);
+      expect(NetworkTablesTypeInfos.validateData([5, 'struct:Pose2d'], array)).toEqual(array);
+    });
+
+    it('should accept Uint8Array for structschema type string', () => {
+      const array = new Uint8Array([100, 111, 117, 98, 108, 101]); // "double" in UTF-8
+      expect(NetworkTablesTypeInfos.validateData([5, 'structschema'], array)).toEqual(array);
+    });
+
+    it('should throw for non-Uint8Array when struct or structschema type expected', () => {
+      expect(() => NetworkTablesTypeInfos.validateData([5, 'struct:Pose2d'], 'not bytes')).toThrow(
+        /Invalid struct value: expected Uint8Array/
+      );
+      expect(() => NetworkTablesTypeInfos.validateData([5, 'structschema'], 'not bytes')).toThrow(
+        /Invalid struct value: expected Uint8Array/
+      );
+    });
+
     it('should return the correct NT type for a boolean array value', () => {
       expect(NetworkTablesTypeInfos.validateData(NetworkTablesTypeInfos.kBooleanArray, [true, false])).toEqual([
         true,

--- a/packages/client/src/lib/types/types.ts
+++ b/packages/client/src/lib/types/types.ts
@@ -67,6 +67,8 @@ export class NetworkTablesTypeInfos {
   static readonly kRPC: NetworkTablesTypeInfo = [5, 'rpc'];
   static readonly kMsgpack: NetworkTablesTypeInfo = [5, 'msgpack'];
   static readonly kProtobuf: NetworkTablesTypeInfo = [5, 'protobuf'];
+  /** Type info for struct schema topics (/.schema/struct:TypeName). Wire type 5 (raw bytes), type string 'structschema'. */
+  static readonly kStructSchema: NetworkTablesTypeInfo = [5, 'structschema'];
   static readonly kBooleanArray: NetworkTablesTypeInfo = [16, 'boolean[]'];
   static readonly kDoubleArray: NetworkTablesTypeInfo = [17, 'double[]'];
   static readonly kIntegerArray: NetworkTablesTypeInfo = [18, 'int[]'];
@@ -131,6 +133,12 @@ export class NetworkTablesTypeInfos {
         } else {
           throw new Error(`Invalid Protobuf value: ${value}`);
         }
+      case NetworkTablesTypeInfos.kStructSchema:
+        if (value instanceof Uint8Array) {
+          return value;
+        } else {
+          throw new Error(`Invalid struct schema value: ${value}`);
+        }
       // 16
       case NetworkTablesTypeInfos.kBooleanArray:
         return z.array(z.boolean()).parse(value);
@@ -148,13 +156,13 @@ export class NetworkTablesTypeInfos {
         return z.array(z.string()).parse(value);
 
       default: {
-        // Type num 5: struct topics (struct:TypeName) and schema topics (structschema) use raw bytes
+        // Type num 5: struct topics store full type in typeInfo (e.g. struct:Pose2d) for topic
+        // reuse/type identity, so we see struct: here. Protobuf topics use kProtobuf [5, 'protobuf']
+        // only; proto:MessageName is used in announce/decoding, not as topic typeInfo.
         const typeString = expectedTypeInfo[1];
-        if (typeof typeString === 'string') {
-          if (typeString === 'structschema' || typeString.startsWith('struct:')) {
-            if (value instanceof Uint8Array) return value;
-            throw new Error(`Invalid struct value: expected Uint8Array`);
-          }
+        if (typeString.startsWith('struct:')) {
+          if (value instanceof Uint8Array) return value;
+          throw new Error(`Invalid struct value: expected Uint8Array`);
         }
         throw new Error(`Invalid type info: ${expectedTypeInfo}`);
       }

--- a/packages/client/src/lib/types/types.ts
+++ b/packages/client/src/lib/types/types.ts
@@ -147,8 +147,15 @@ export class NetworkTablesTypeInfos {
       case NetworkTablesTypeInfos.kStringArray:
         return z.array(z.string()).parse(value);
 
-      default:
+      default: {
+        // struct: type strings use type num 5 but have dynamic names (e.g. "struct:Pose2d")
+        const typeString = expectedTypeInfo[1];
+        if (typeof typeString === 'string' && typeString.startsWith('struct:')) {
+          if (value instanceof Uint8Array) return value;
+          throw new Error(`Invalid struct value: expected Uint8Array`);
+        }
         throw new Error(`Invalid type info: ${expectedTypeInfo}`);
+      }
     }
   }
 }

--- a/packages/client/src/lib/types/types.ts
+++ b/packages/client/src/lib/types/types.ts
@@ -148,11 +148,13 @@ export class NetworkTablesTypeInfos {
         return z.array(z.string()).parse(value);
 
       default: {
-        // struct: type strings use type num 5 but have dynamic names (e.g. "struct:Pose2d")
+        // Type num 5: struct topics (struct:TypeName) and schema topics (structschema) use raw bytes
         const typeString = expectedTypeInfo[1];
-        if (typeof typeString === 'string' && typeString.startsWith('struct:')) {
-          if (value instanceof Uint8Array) return value;
-          throw new Error(`Invalid struct value: expected Uint8Array`);
+        if (typeof typeString === 'string') {
+          if (typeString === 'structschema' || typeString.startsWith('struct:')) {
+            if (value instanceof Uint8Array) return value;
+            throw new Error(`Invalid struct value: expected Uint8Array`);
+          }
         }
         throw new Error(`Invalid type info: ${expectedTypeInfo}`);
       }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -6,6 +6,8 @@ export { usePrefixTopic, usePrefixTopicMap } from './lib/use-prefix-topic';
 export type { PrefixTopicUpdate } from './lib/use-prefix-topic';
 export { useProtobufTopic } from './lib/use-protobuf-topic';
 export type { UseProtobufTopicOptions, UseProtobufTopicResult } from './lib/use-protobuf-topic';
+export { useStructTopic } from './lib/use-struct-topic';
+export type { UseStructTopicOptions, UseStructTopicResult } from './lib/use-struct-topic';
 export { useConnectionStatus } from './lib/use-connection-status';
 
 export type { NetworkTablesTypeInfo, NetworkTablesTypes, SubscribeOptions, TopicProperties } from '@ntcore/client';

--- a/packages/react/src/lib/use-struct-topic.spec.tsx
+++ b/packages/react/src/lib/use-struct-topic.spec.tsx
@@ -77,4 +77,17 @@ describe('useStructTopic', () => {
     });
     expect(mockStructTopic.setValue).toHaveBeenCalledWith({ x: 3, y: 4 });
   });
+
+  it('supports array-of-struct type (Translation2d[]) without cast', () => {
+    type Translation2d = { x: number; y: number };
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <NtcoreProvider uri="localhost">{children}</NtcoreProvider>
+    );
+    const { result } = renderHook(
+      () => useStructTopic<Translation2d[]>('/struct/arr', { typeName: 'Translation2d[]' }),
+      { wrapper }
+    );
+    expect(result.current.value).toBeNull();
+    expect(mockNt.createStructTopic).toHaveBeenCalledWith('/struct/arr', { typeName: 'Translation2d[]' });
+  });
 });

--- a/packages/react/src/lib/use-struct-topic.spec.tsx
+++ b/packages/react/src/lib/use-struct-topic.spec.tsx
@@ -1,0 +1,80 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NtcoreProvider } from './context';
+import { useStructTopic } from './use-struct-topic';
+
+const mockUnsubscribe = vi.fn();
+const mockSubscribe = vi.fn((cb: (v: unknown) => void) => {
+  setTimeout(() => cb({ x: 1, y: 2 }), 0);
+  return 88;
+});
+const mockStructTopic = {
+  subscribe: mockSubscribe,
+  unsubscribe: mockUnsubscribe,
+  setValue: vi.fn(),
+  publish: vi.fn().mockResolvedValue(undefined),
+};
+
+const mockNt = {
+  createStructTopic: vi.fn(() => mockStructTopic),
+  addRobotConnectionListener: vi.fn(() => vi.fn()),
+};
+
+vi.mock('@ntcore/client', () => ({
+  NetworkTables: {
+    getInstanceByTeam: vi.fn(() => mockNt),
+    getInstanceByURI: vi.fn(() => mockNt),
+  },
+  NetworkTablesTypeInfos: {},
+}));
+
+describe('useStructTopic', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns value, setValue, isReadyToWrite', () => {
+    const { result } = renderHook(() => useStructTopic<{ x: number; y: number }>('/struct/pose'));
+    expect(result.current.value).toBeNull();
+    expect(result.current.setValue).toBeUndefined();
+    expect(result.current.isReadyToWrite).toBe(false);
+  });
+
+  it('subscribes on mount, unsubscribes on unmount', async () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <NtcoreProvider uri="localhost">{children}</NtcoreProvider>
+    );
+    const { result, unmount } = renderHook(
+      () => useStructTopic<{ x: number; y: number }>('/struct/t', { typeName: 'Translation2d' }),
+      { wrapper }
+    );
+    expect(mockNt.createStructTopic).toHaveBeenCalledWith('/struct/t', { typeName: 'Translation2d' });
+    expect(mockSubscribe).toHaveBeenCalled();
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+    expect(result.current.value).toEqual({ x: 1, y: 2 });
+    unmount();
+    expect(mockUnsubscribe).toHaveBeenCalledWith(88);
+  });
+
+  it('setValue only when isReadyToWrite (publish path)', async () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <NtcoreProvider uri="localhost">{children}</NtcoreProvider>
+    );
+    const { result } = renderHook(
+      () => useStructTopic<{ x: number; y: number }>('/struct/t', { typeName: 'Translation2d', publish: true }),
+      { wrapper }
+    );
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+    expect(result.current.isReadyToWrite).toBe(true);
+    const setValue = result.current.setValue;
+    expect(setValue).toBeDefined();
+    act(() => {
+      if (setValue) setValue({ x: 3, y: 4 });
+    });
+    expect(mockStructTopic.setValue).toHaveBeenCalledWith({ x: 3, y: 4 });
+  });
+});

--- a/packages/react/src/lib/use-struct-topic.ts
+++ b/packages/react/src/lib/use-struct-topic.ts
@@ -6,7 +6,7 @@ import type { ZodSchema } from 'zod';
 /**
  * Options for useStructTopic (defaultValue, validator, typeName, schema, subscribeOptions, publish).
  */
-export type UseStructTopicOptions<T extends Record<string, unknown>> = {
+export type UseStructTopicOptions<T extends Record<string, unknown> | Record<string, unknown>[]> = {
   defaultValue?: T;
   validator?: ZodSchema<T>;
   typeName?: string;
@@ -23,7 +23,7 @@ export type UseStructTopicOptions<T extends Record<string, unknown>> = {
  * Result of useStructTopic. When you pass `publish`, setValue is defined and you must
  * wait for isReadyToWrite before calling it.
  */
-export type UseStructTopicResult<T extends Record<string, unknown>> = {
+export type UseStructTopicResult<T extends Record<string, unknown> | Record<string, unknown>[]> = {
   value: T | null;
   setValue: ((value: T) => void) | undefined;
   /** True once the server has acknowledged our publish request. */
@@ -45,7 +45,7 @@ export type UseStructTopicResult<T extends Record<string, unknown>> = {
  * @param options - Optional typeName, schema, defaultValue, validator, subscribeOptions, publish.
  * @returns { value, setValue, isReadyToWrite }.
  */
-export function useStructTopic<T extends Record<string, unknown>>(
+export function useStructTopic<T extends Record<string, unknown> | Record<string, unknown>[]>(
   name: string,
   options?: UseStructTopicOptions<T>
 ): UseStructTopicResult<T> {

--- a/packages/react/src/lib/use-struct-topic.ts
+++ b/packages/react/src/lib/use-struct-topic.ts
@@ -1,0 +1,109 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import type { SubscribeOptions, TopicProperties } from '@ntcore/client';
+import { useNtcore } from './context';
+import type { ZodSchema } from 'zod';
+
+/**
+ * Options for useStructTopic (defaultValue, validator, typeName, schema, subscribeOptions, publish).
+ */
+export type UseStructTopicOptions<T extends Record<string, unknown>> = {
+  defaultValue?: T;
+  validator?: ZodSchema<T>;
+  typeName?: string;
+  schema?: string;
+  subscribeOptions?: SubscribeOptions;
+  /**
+   * Make this client the publisher of the topic so you can write with setValue.
+   * When provided, only call setValue after isReadyToWrite is true.
+   */
+  publish?: true | TopicProperties;
+};
+
+/**
+ * Result of useStructTopic. When you pass `publish`, setValue is defined and you must
+ * wait for isReadyToWrite before calling it.
+ */
+export type UseStructTopicResult<T extends Record<string, unknown>> = {
+  value: T | null;
+  setValue: ((value: T) => void) | undefined;
+  /** True once the server has acknowledged our publish request. */
+  isReadyToWrite: boolean;
+};
+
+/**
+ * Subscribes to a NetworkTables struct topic and returns the latest decoded value.
+ * Unsubscribes on unmount.
+ *
+ * **Reading only:** Omit `publish` in options.
+ *
+ * **Reading and writing:** Pass `publish: true` or `publish: { retained: true }` in options.
+ * Only call setValue when isReadyToWrite is true.
+ *
+ * Subscription is re-created only when `nt` or `name` change. Optional options are read at subscribe time.
+ *
+ * @param name - Topic name (e.g. "/MyTable/PoseStruct").
+ * @param options - Optional typeName, schema, defaultValue, validator, subscribeOptions, publish.
+ * @returns { value, setValue, isReadyToWrite }.
+ */
+export function useStructTopic<T extends Record<string, unknown>>(
+  name: string,
+  options?: UseStructTopicOptions<T>
+): UseStructTopicResult<T> {
+  const nt = useNtcore();
+  const [state, setState] = useState<T | null>(options?.defaultValue ?? null);
+  const [isReadyToWrite, setIsReadyToWrite] = useState(false);
+  const optionsRef = useRef(options);
+
+  useLayoutEffect(() => {
+    optionsRef.current = options;
+  });
+
+  useEffect(() => {
+    if (!nt) return;
+    let cancelled = false;
+    queueMicrotask(() => {
+      if (!cancelled) {
+        setState(optionsRef.current?.defaultValue ?? null);
+        setIsReadyToWrite(false);
+      }
+    });
+    const topic = nt.createStructTopic<T>(name, optionsRef.current);
+    const subuid = topic.subscribe((v) => setState(v ?? null), optionsRef.current?.subscribeOptions ?? undefined);
+    const publish = optionsRef.current?.publish;
+    if (publish !== undefined) {
+      const properties = publish === true ? {} : publish;
+      topic
+        .publish(properties)
+        .then(() => {
+          if (!cancelled) setIsReadyToWrite(true);
+        })
+        .catch(() => {
+          /* publish failure: do not update state */
+        });
+      return () => {
+        cancelled = true;
+        topic.unsubscribe(subuid);
+      };
+    }
+    return () => {
+      cancelled = true;
+      topic.unsubscribe(subuid);
+    };
+  }, [nt, name]);
+
+  const setValueCb = useCallback(
+    (value: T) => {
+      if (!nt) return;
+      const publish = optionsRef.current?.publish;
+      if (publish !== undefined && !isReadyToWrite) return;
+      const topic = nt.createStructTopic<T>(name, optionsRef.current);
+      topic.setValue(value);
+    },
+    [nt, name, isReadyToWrite]
+  );
+
+  const isPublisher = options?.publish !== undefined;
+  const setValue = nt !== null && isPublisher ? setValueCb : undefined;
+
+  return { value: state, setValue, isReadyToWrite };
+}


### PR DESCRIPTION
Fixes #163 

This pull request introduces comprehensive support for WPILib "struct" types (such as `Pose2d`, `Translation2d`, etc.) in the NetworkTables TypeScript client and example apps. It adds new APIs for creating, subscribing to, and publishing struct topics, ensures proper interoperability with WPILib Java and C++ clients, and includes documentation and tests to validate the new functionality. The changes are grouped below by theme.

**Struct topic support in NetworkTables client:**

* Added `createStructTopic` API to `NetworkTables` for creating and managing struct topics, with type-safe options for built-in and custom types, validation, and schema support. Throws an error if struct types are used with `createTopic`. [[1]](diffhunk://#diff-472df79a7145fd3c8069e0e88d0a1f43695b7874f5760eb026c4a870f36d93a9R208-R212) [[2]](diffhunk://#diff-472df79a7145fd3c8069e0e88d0a1f43695b7874f5760eb026c4a870f36d93a9R246-R285) [[3]](diffhunk://#diff-04347b71a44b05d4818868742a11a551b68869870f920fa46e18b91d034cf45bR118-R146)
* Exported `NetworkTablesStructTopic` from the pubsub index for external usage.
* Integrated `StructSchemaManager` into the pubsub client for schema management. [[1]](diffhunk://#diff-39a0370b11216a928cb5ab42d36743c0d33481ea5b3e250bb3c00a30d8d23f47R13) [[2]](diffhunk://#diff-39a0370b11216a928cb5ab42d36743c0d33481ea5b3e250bb3c00a30d8d23f47R29)

**Documentation and examples:**

* Updated `README.md` with a new section describing struct topic usage, including built-in types, subscription and publishing examples, array support, and React integration via `useStructTopic`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R13) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R236-R282)
* Added example code in `apps/example-client/src/main.ts` for subscribing to a struct topic (`Pose2d`).

**End-to-end and unit testing:**

* Added E2E tests for struct topics: subscribing to a robot-published struct, publishing from client and verifying echo-back from robot, and error handling for incorrect API usage. [[1]](diffhunk://#diff-8a2c60fe85b8795f21880ca2f16548be51f1bfa2a9ccf9f6d4f57c6e8c764505R101-R168) [[2]](diffhunk://#diff-04347b71a44b05d4818868742a11a551b68869870f920fa46e18b91d034cf45bR118-R146)

**Example robot support for struct topics:**

* Robot now publishes `Pose2d` as both protobuf and struct topics, subscribes to client-published struct topics, and echoes them for verification. Struct topics are reset on disable and updated in periodic/test modes. [[1]](diffhunk://#diff-5e9f08a6a66e8008470624a22cff70c276af174e6d378b04093808457c4488cbR24-R27) [[2]](diffhunk://#diff-5e9f08a6a66e8008470624a22cff70c276af174e6d378b04093808457c4488cbR50-R58) [[3]](diffhunk://#diff-5e9f08a6a66e8008470624a22cff70c276af174e6d378b04093808457c4488cbR71-R74) [[4]](diffhunk://#diff-5e9f08a6a66e8008470624a22cff70c276af174e6d378b04093808457c4488cbR124) [[5]](diffhunk://#diff-5e9f08a6a66e8008470624a22cff70c276af174e6d378b04093808457c4488cbL136-R156)

**React example app integration:**

* Added `PoseStructCard` component to visualize struct topic data, and included it in the main app UI. [[1]](diffhunk://#diff-09a8d06b304935197ba73ee3b390e0796b79c24f349919892c26d2c986c378f6R9) [[2]](diffhunk://#diff-09a8d06b304935197ba73ee3b390e0796b79c24f349919892c26d2c986c378f6R54) [[3]](diffhunk://#diff-2dc90b26582e6fe8417d6fc734910b5d6205ce261e0b5fc45425c57a9ee2c525R1-R59)